### PR TITLE
Visual cooldown bars and cursor sync

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -2,11 +2,15 @@ import React, { useEffect, useRef } from 'react';
 import { DataSet, Timeline as VisTimeline } from 'vis-timeline/standalone';
 import type { DataItem, DataGroup } from 'vis-timeline';
 
+// Item displayed on the timeline. `end` is optional so we can draw range
+// bars (used for cooldown visualization).
 export interface TLItem {
   id: number;
-  group: number;  // 1-4
-  start: number;  // seconds
+  group: number;     // group id 1-4
+  start: number;     // start time in seconds
+  end?: number;      // optional end time in seconds
   label: string;
+  className?: string;
 }
 
 const groups = [
@@ -16,21 +20,34 @@ const groups = [
   '踏风技能(4)',
 ];
 
+// Position of a cooldown finishing mark shown as a vertical line
 export interface CDLine { id: string; time: number; }
+interface Props {
+  items: TLItem[];
+  duration: number;
+  cursor: number;
+  cds: CDLine[];
+  showCD: boolean;
+  // notify parent when the cursor (blue line) moves
+  onCursorChange?: (t: number) => void;
+}
 
-export const Timeline = ({ items, duration, cursor, cds, showCD }:{ items: TLItem[]; duration: number; cursor:number; cds: CDLine[]; showCD:boolean }) => {
+export const Timeline = ({ items, duration, cursor, cds, showCD, onCursorChange }: Props) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const timelineRef = useRef<VisTimeline | null>(null);
   const groupDS = useRef(new DataSet<DataGroup>(
     groups.map((g, i) => ({ id: i + 1, content: g }))
   ));
+  // dataset for the timeline items
   const itemDS = useRef(new DataSet<DataItem>());
+  // flag to ensure custom time is added only once
   const cursorAdded = useRef(false);
+  // ids of custom time markers used for cd lines
   const cdIds = useRef<string[]>([]);
 
   useEffect(() => {
     if (!containerRef.current || timelineRef.current) return;
-    timelineRef.current = new VisTimeline(
+    const tl = new VisTimeline(
       containerRef.current,
       itemDS.current,
       groupDS.current,
@@ -50,13 +67,27 @@ export const Timeline = ({ items, duration, cursor, cds, showCD }:{ items: TLIte
         },
       }
     );
-  }, []);
+    timelineRef.current = tl;
+    // allow dragging the custom time and clicking to change it
+    tl.on('timechanged', props => {
+      if (props.id === 'cursor' && onCursorChange) {
+        onCursorChange(props.time.valueOf() / 1000);
+      }
+    });
+    tl.on('click', props => {
+      if (props.time) {
+        tl.setCustomTime(props.time, 'cursor');
+        onCursorChange?.(props.time.valueOf() / 1000);
+      }
+    });
+  }, [onCursorChange]);
 
   useEffect(() => {
     timelineRef.current?.setWindow(new Date(0), new Date(duration * 1000));
   }, [duration]);
 
   useEffect(() => {
+    // rebuild dataset whenever items change
     itemDS.current.clear();
     itemDS.current.add(
       items.map(it => ({
@@ -64,12 +95,16 @@ export const Timeline = ({ items, duration, cursor, cds, showCD }:{ items: TLIte
         group: it.group,
         content: it.label,
         start: new Date(it.start * 1000),
+        end: it.end ? new Date(it.end * 1000) : undefined,
+        type: it.end ? 'range' : 'box',
+        className: it.className,
       }))
     );
     timelineRef.current?.setWindow(new Date(0), new Date(duration * 1000));
   }, [items]);
 
   useEffect(() => {
+    // keep custom time (blue line) in sync with cursor value
     if (!timelineRef.current) return;
     const tl = timelineRef.current;
     if (!cursorAdded.current) {
@@ -81,6 +116,7 @@ export const Timeline = ({ items, duration, cursor, cds, showCD }:{ items: TLIte
   }, [cursor]);
 
   useEffect(() => {
+    // redraw cooldown end lines whenever they change
     if (!timelineRef.current) return;
     const tl = timelineRef.current;
     cdIds.current.forEach(id => tl.removeCustomTime(id));

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,9 @@ body.light {
   background: #fff;
   color: #000;
 }
+
+/* style for cooldown range bars */
+.vis-item.cd-bar {
+  background-color: rgba(0, 128, 255, 0.2);
+  border-color: rgba(0, 128, 255, 0.5);
+}


### PR DESCRIPTION
## Summary
- visualize ability cooldowns as range bars on the timeline
- update cursor time when user drags or clicks the timeline
- show remaining cooldown next to ability buttons
- style cooldown bars
- add explanatory comments

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c3da62c64832fbd65e3454117db44