### PR TITLE
Fix cooldowns and add debug info

### DIFF
--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -238,7 +238,7 @@
       {}
     ],
     "gcd": 1,
-    "cooldown": 120
+    "cooldown": 90
   },
   {
     "name": "SEF",


### PR DESCRIPTION
## Summary
- fix Xuen cooldown to 90s
- allow entering stats as percentages
- apply haste to cooldowns using percentage value
- add debug info for haste, SEF charges and cursor time
- avoid off-by-one when showing cooldowns

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c4229bb94832fa4e42ab1b985122b