### PR TITLE
Add haste CD recalculation and timeline editing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,8 @@ body.light {
   background-color: rgba(0, 128, 255, 0.2);
   border-color: rgba(0, 128, 255, 0.5);
 }
+
+.vis-item.highlight {
+  background-color: rgba(255, 0, 0, 0.4);
+  border-color: red;
+}


### PR DESCRIPTION
## Summary
- recalc existing cooldowns when haste changes
- allow dragging and context-menu actions on timeline items
- support highlighting and deletion via right-click

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c48940b44832fa76380f3905a5fbf