### PR TITLE
Fix Xuen warning border

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -26,4 +26,6 @@ body.light {
 }
 
 .vis-item.warning { border-color: orange; }
+/* ensure selected items keep the warning color */
+.vis-item.warning.vis-selected { border-color: orange; }
 


### PR DESCRIPTION
## Summary
- ensure cooldown warning border remains orange when selected

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c5186d828832f870ab7c1ee6ff406