### PR TITLE
Fix cooldown display for overlapping items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,9 +125,12 @@ export default function App() {
     const cds = (cooldowns[key] || []).filter(cd => cd.start <= time && cd.end > time);
     const maxCharges = key === 'SEF' ? ability.charges ?? 2 : 1;
     if (cds.length < maxCharges) return 'Ready';
+    const end = maxCharges === 1
+      ? Math.max(...cds.map(cd => cd.end))
+      : Math.min(...cds.map(cd => cd.end));
     const remaining = Math.max(
       0,
-      Math.ceil(Math.min(...cds.map(cd => cd.end)) - time - 1e-6)
+      Math.ceil(end - time - 1e-6)
     );
     return `CD ${remaining}s`;
   };


### PR DESCRIPTION
## Summary
- handle overlapping cooldowns when showing ability status

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c57097e8c832fb009fd64fbd698cd