### PR TITLE
Update timeline groups and add boss placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,16 +67,16 @@ export default function App() {
 
   // mapping from ability key to timeline group
   const groupMap: Record<WWKey, number> = {
-    Xuen: 1,
-    SEF: 1,
-    CC: 1,
-    AA: 2,
-    SW: 2,
-    FoF: 3,
-    RSK: 3,
-    WU: 3,
-    TP: 4,
-    BOK: 4,
+    Xuen: 2,
+    SEF: 2,
+    CC: 2,
+    AA: 3,
+    SW: 3,
+    FoF: 4,
+    RSK: 4,
+    WU: 4,
+    TP: 5,
+    BOK: 5,
   };
 
   // handler when an ability button is clicked
@@ -212,6 +212,7 @@ export default function App() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">踏风排轴器</h1>
+      <h1 className="text-xl">Boss时间轴选项</h1>
       <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
         className="px-2 py-1 border rounded">
         切换 {theme === 'dark' ? '浅色' : '深色'}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -6,7 +6,7 @@ import type { DataItem, DataGroup } from "vis-timeline";
 // bars (used for cooldown visualization).
 export interface TLItem {
   id: number;
-  group: number; // group id 1-4
+  group: number; // group id 1-5
   start: number; // start time in seconds
   end?: number; // optional end time in seconds
   label: string;
@@ -14,7 +14,13 @@ export interface TLItem {
   className?: string;
 }
 
-const groups = ["踏风技能(1)", "踏风技能(2)", "踏风技能(3)", "踏风技能(4)"];
+const groups = [
+  "Boss技能",
+  "Major Cooldown",
+  "Minor Cooldown",
+  "Major Filler",
+  "Minor Filler",
+];
 
 // Position of a cooldown finishing mark shown as a vertical line
 export interface CDLine {


### PR DESCRIPTION
## Summary
- rename timeline groups to match role
- add a boss group to the timeline
- shift ability group mapping accordingly
- add heading placeholder for boss timeline option

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c6f912e58832fb29e961dcabe58bf