### PR TITLE
Add channel duration support

### DIFF
--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -283,6 +283,7 @@
     "effects": [
       {}
     ],
+    "cast": 4,
     "gcd": 1,
     "cooldown": 90
   }


### PR DESCRIPTION
## Summary
- show channel cast time for FoF and CC
- prevent using other abilities during a channel
- keep channel duration when moving items
- mark CC as a channeled spell

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c75119d30832f92ccba0dfe47bffb