### PR TITLE
Implement cooldown simulation and fix removal logic

### DIFF
--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -1,28 +1,100 @@
 import { describe, it, expect } from 'vitest';
-import { startSkill, tick, removeSkill, Skill } from '../logic/cooldown';
+import { startSkill, tick, removeSkill, simulate, Skill } from '../logic/cooldown';
 
 const WU: Skill = { id: 'WU', castTime: 500, cooldown: 8000 };
 const AA: Skill = { id: 'AA', castTime: 1000, cooldown: 5000 };
 
 describe('cooldown utilities', () => {
-  it('deducts cast time from existing cooldowns', () => {
-    let cd = startSkill({}, WU); // WU -> 8500
-    cd = tick(cd, 500); // WU -> 8000
-    cd = startSkill(cd, AA); // should deduct 1000 from WU
-    expect(cd.WU).toBe(7000);
-    expect(cd.AA).toBe(6000);
+  it('handles cast time deduction when chaining', () => {
+    let cd = startSkill({}, WU);
+    cd = tick(cd, 500);
+    cd = startSkill(cd, AA);
+    expect(cd['WU']).toBe(7000);
   });
 
-  it('removeSkill deletes cooldown entry', () => {
+  it('removes skill before cooldown ends', () => {
     let cd = startSkill({}, WU);
+    cd = tick(cd, 3000); // WU -> 5500
     cd = removeSkill(cd, 'WU');
-    expect(cd.WU).toBeUndefined();
+    expect(cd['WU']).toBeUndefined();
   });
 
-  it('applyElapsed prevents negatives', () => {
-    let cd = startSkill({}, WU);
-    cd = tick(cd, 9000);
-    expect(cd.WU).toBeUndefined();
+  it('simulate entire timeline', () => {
+    const timeline = simulate(
+      [
+        { t: 0, op: 'start', skill: WU },
+        { t: 500, op: 'start', skill: AA },
+        { t: 2500, op: 'remove', id: 'AA' },
+      ],
+      10000,
+      1000,
+    );
+    expect(timeline).toMatchInlineSnapshot(`
+      [
+        {
+          "cd": {
+            "WU": 8500,
+          },
+          "t": 0,
+        },
+        {
+          "cd": {
+            "AA": 5500,
+            "WU": 6500,
+          },
+          "t": 1000,
+        },
+        {
+          "cd": {
+            "AA": 4500,
+            "WU": 5500,
+          },
+          "t": 2000,
+        },
+        {
+          "cd": {
+            "WU": 4500,
+          },
+          "t": 3000,
+        },
+        {
+          "cd": {
+            "WU": 3500,
+          },
+          "t": 4000,
+        },
+        {
+          "cd": {
+            "WU": 2500,
+          },
+          "t": 5000,
+        },
+        {
+          "cd": {
+            "WU": 1500,
+          },
+          "t": 6000,
+        },
+        {
+          "cd": {
+            "WU": 500,
+          },
+          "t": 7000,
+        },
+        {
+          "cd": {},
+          "t": 8000,
+        },
+        {
+          "cd": {},
+          "t": 9000,
+        },
+        {
+          "cd": {},
+          "t": 10000,
+        },
+      ]
+    `);
   });
 });
 

--- a/src/logic/cooldown.ts
+++ b/src/logic/cooldown.ts
@@ -6,26 +6,24 @@ export interface Skill {
 
 export type CooldownMap = Record<string, number>;
 
-/** apply elapsed time to cooldown map and remove expired entries */
-export function applyElapsed(cd: CooldownMap, elapsed: number): CooldownMap {
+/**
+ * Apply elapsed time to a cooldown map.
+ * All values are reduced by `elapsed` and expired entries are removed.
+ */
+function applyElapsed(cd: CooldownMap, elapsed: number): CooldownMap {
   if (elapsed <= 0) return { ...cd };
   const out: CooldownMap = {};
-  for (const [k, v] of Object.entries(cd)) {
-    const nv = v - elapsed;
-    if (nv > 0) out[k] = nv;
+  for (const [id, left] of Object.entries(cd)) {
+    const next = left - elapsed;
+    if (next > 0) out[id] = next;
   }
   return out;
 }
 
 /** start cooldown for a skill */
-export function startSkill(
-  cd: CooldownMap,
-  s: Skill,
-  now = Date.now(),
-): CooldownMap {
+export function startSkill(cd: CooldownMap, s: Skill): CooldownMap {
   const after = applyElapsed(cd, s.castTime);
-  after[s.id] = s.cooldown + s.castTime;
-  return after;
+  return { ...after, [s.id]: s.cooldown + s.castTime };
 }
 
 /** advance cooldowns by dt milliseconds */
@@ -36,7 +34,47 @@ export function tick(cd: CooldownMap, dt: number): CooldownMap {
 /** remove a skill from cooldown tracking */
 export function removeSkill(cd: CooldownMap, id: string): CooldownMap {
   const { [id]: _, ...rest } = cd;
-  return rest;
+  return { ...rest };
+}
+
+export type SimulationAction =
+  | { t: number; op: 'start'; skill: Skill }
+  | { t: number; op: 'remove'; id: string };
+
+export function simulate(
+  actions: SimulationAction[],
+  totalMs: number,
+  stepMs = 1000,
+): Array<{ t: number; cd: CooldownMap }> {
+  const timeline: Array<{ t: number; cd: CooldownMap }> = [];
+  const sorted = [...actions].sort((a, b) => a.t - b.t);
+  let idx = 0;
+  let current = 0;
+  let cd: CooldownMap = {};
+
+  // process actions at t=0
+  while (idx < sorted.length && sorted[idx].t <= 0) {
+    const act = sorted[idx++];
+    cd = act.op === 'start' ? startSkill(cd, act.skill) : removeSkill(cd, act.id);
+  }
+  timeline.push({ t: 0, cd: { ...cd } });
+
+  while (current < totalMs) {
+    const next = Math.min(current + stepMs, totalMs);
+    let t = current;
+    while (idx < sorted.length && sorted[idx].t <= next) {
+      const actTime = sorted[idx].t;
+      cd = tick(cd, actTime - t);
+      t = actTime;
+      const act = sorted[idx++];
+      cd = act.op === 'start' ? startSkill(cd, act.skill) : removeSkill(cd, act.id);
+    }
+    cd = tick(cd, next - t);
+    current = next;
+    timeline.push({ t: current, cd: { ...cd } });
+  }
+
+  return timeline;
 }
 
 // END_PATCH


### PR DESCRIPTION
## Summary
- refactor cooldown utilities
- add simulation API for per-second snapshots
- update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d28f649e4832f8ceb0d19d795901d