### PR TITLE
Refactor cooldown system to absolute timestamps

### DIFF
--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -1,100 +1,29 @@
-import { describe, it, expect } from 'vitest';
-import { startSkill, tick, removeSkill, simulate, Skill } from '../logic/cooldown';
+import { describe, expect, it } from 'vitest';
+import { Skill, startSkill, advance, timeline } from '../logic/cooldown';
 
-const WU: Skill = { id: 'WU', castTime: 500, cooldown: 8000 };
-const AA: Skill = { id: 'AA', castTime: 1000, cooldown: 5000 };
+const AA: Skill = { id: 'AA', castTime: 0, cooldown: 30000 };
+const QL: Skill = { id: 'QL', castTime: 0, cooldown: 0 };
 
-describe('cooldown utilities', () => {
-  it('handles cast time deduction when chaining', () => {
-    let cd = startSkill({}, WU);
-    cd = tick(cd, 500);
-    cd = startSkill(cd, AA);
-    expect(cd['WU']).toBe(7000);
+describe('Cooldown – absolute timestamp model', () => {
+  it('AA should be ready at 25.5 s, not 17.1 s', () => {
+    let cd = startSkill({}, AA, 0);
+    cd = advance(cd, 0, 4500);
+    expect(cd.AA - 4500).toBe(25500);
   });
 
-  it('removes skill before cooldown ends', () => {
-    let cd = startSkill({}, WU);
-    cd = tick(cd, 3000); // WU -> 5500
-    cd = removeSkill(cd, 'WU');
-    expect(cd['WU']).toBeUndefined();
-  });
-
-  it('simulate entire timeline', () => {
-    const timeline = simulate(
+  it('timeline produces correct per-1000ms snapshot', () => {
+    const shots = timeline(
+      {},
       [
-        { t: 0, op: 'start', skill: WU },
-        { t: 500, op: 'start', skill: AA },
-        { t: 2500, op: 'remove', id: 'AA' },
+        { t: 0, op: 'start', skill: AA },
+        { t: 0, op: 'start', skill: QL },
+        { t: 4500, op: 'remove', id: 'QL' },
       ],
-      10000,
+      30000,
       1000,
     );
-    expect(timeline).toMatchInlineSnapshot(`
-      [
-        {
-          "cd": {
-            "WU": 8500,
-          },
-          "t": 0,
-        },
-        {
-          "cd": {
-            "AA": 5500,
-            "WU": 6500,
-          },
-          "t": 1000,
-        },
-        {
-          "cd": {
-            "AA": 4500,
-            "WU": 5500,
-          },
-          "t": 2000,
-        },
-        {
-          "cd": {
-            "WU": 4500,
-          },
-          "t": 3000,
-        },
-        {
-          "cd": {
-            "WU": 3500,
-          },
-          "t": 4000,
-        },
-        {
-          "cd": {
-            "WU": 2500,
-          },
-          "t": 5000,
-        },
-        {
-          "cd": {
-            "WU": 1500,
-          },
-          "t": 6000,
-        },
-        {
-          "cd": {
-            "WU": 500,
-          },
-          "t": 7000,
-        },
-        {
-          "cd": {},
-          "t": 8000,
-        },
-        {
-          "cd": {},
-          "t": 9000,
-        },
-        {
-          "cd": {},
-          "t": 10000,
-        },
-      ]
-    `);
+    expect(shots[5].cd.AA - shots[5].t).toBeGreaterThan(24999);
+    expect(shots[5].cd.AA - shots[5].t).toBeLessThan(25001);
   });
 });
 


### PR DESCRIPTION
## Summary
- implement cooldown tracking via absolute `readyAt` timestamps
- provide `advance` and `timeline` helpers for stepping through time
- update tests for new cooldown behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d3241cd30832f8864680903ee632e