### PR TITLE
Fix cooldown calculation with segment integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Timeline, TLItem } from './components/Timeline';
 import { wwData, WWKey } from './jobs/windwalker';
 import { ratingToHaste } from './lib/haste';
+import { computeCooldownEnd } from './lib/computeCooldown';
 import TPIcon from './Pics/TP.jpg';
 
 export default function App() {
@@ -194,15 +195,22 @@ export default function App() {
 
     const baseCd = ability.cooldown ?? 0;
     const futureBuffs = [...extraBuffs];
-    const hastePct = hasteAt(now, futureBuffs);
-    const cdSpd = cdSpeedAt(now, futureBuffs);
-    const finalCd = ['RSK','FoF','WU'].includes(key)
-      ? baseCd / ((1 + hastePct) * cdSpd)
-      : baseCd / cdSpd;
+    const endAt = computeCooldownEnd(now, baseCd, futureBuffs, t =>
+      cdSpeedAt(t, futureBuffs)
+    );
     // store cooldown range so it can be visualised later
     setCooldowns(cdObj => ({
       ...cdObj,
-      [key]: [...cds, { id, start: now, base: baseCd, hasted: ['RSK','FoF','WU'].includes(key), end: now + finalCd }],
+      [key]: [
+        ...cds,
+        {
+          id,
+          start: now,
+          base: baseCd,
+          hasted: false,
+          end: endAt,
+        },
+      ],
     }));
     setTime(now + (castDur > 0 ? castDur : 1));
   };

--- a/src/__tests__/computeCooldown.test.ts
+++ b/src/__tests__/computeCooldown.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { computeCooldownEnd, Buff } from '../lib/computeCooldown';
+
+const speedFn = (buffs: Buff[]) => (t: number) => {
+  for (const b of buffs) {
+    if (t >= b.start && t < b.end) {
+      if (b.start === 0 && b.end === 6) return 1.75; // AA dragon
+    }
+  }
+  if (buffs.some(b => b.start === 2 && b.end === 8 && t >= b.start && t < b.end)) {
+    return 2.5; // CC dragon
+  }
+  return 1;
+};
+
+describe('computeCooldownEnd', () => {
+  it('AA after 0 s, QL 6×0.75 s ⇒ CD ends at 25.5 s', () => {
+    const buffs: Buff[] = [{ start: 0, end: 6 }];
+    const end = computeCooldownEnd(0, 30, buffs, t => (t < 6 ? 1.75 : 1));
+    expect(end).toBeCloseTo(25.5, 2);
+  });
+
+  it('AA then CC at 2 s ⇒ CD ends around 19.5 s', () => {
+    const buffs: Buff[] = [
+      { start: 0, end: 2 },
+      { start: 2, end: 8 },
+    ];
+    const cdSpd = (t: number) => {
+      if (t < 2) return 1.75; // AA dragon
+      if (t < 8) return 2.5; // CC dragon
+      return 1;
+    };
+    const end = computeCooldownEnd(0, 30, buffs, cdSpd);
+    expect(end).toBeCloseTo(19.5, 2);
+  });
+});
+
+// END_PATCH

--- a/src/lib/computeCooldown.ts
+++ b/src/lib/computeCooldown.ts
@@ -1,0 +1,31 @@
+export interface Buff { start: number; end: number }
+
+export function computeCooldownEnd(
+  start: number,
+  baseCd: number,
+  events: Buff[],
+  cdSpeedAt: (t: number) => number,
+): number {
+  const points = Array.from(
+    new Set(
+      events
+        .flatMap(b => [b.start, b.end])
+        .filter(t => t > start)
+    ),
+  ).sort((a, b) => a - b);
+
+  let remain = baseCd;
+  let prev = start;
+  for (const p of points) {
+    const speed = cdSpeedAt((prev + p) / 2);
+    const delta = (p - prev) * speed;
+    if (delta >= remain) {
+      return prev + remain / speed;
+    }
+    remain -= delta;
+    prev = p;
+  }
+  return prev + remain;
+}
+
+// END_PATCH


### PR DESCRIPTION
## Summary
- introduce `computeCooldownEnd` for accurate cooldown tracking
- use new function in App
- add unit tests for the cooldown math

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d36381218832fa3644ed0fcc4d6cb