### PR TITLE
Implement timeline simulator and fmtSec

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Timeline, TLItem } from './components/Timeline';
 import { wwData, WWKey } from './jobs/windwalker';
 import { ratingToHaste } from './lib/haste';
 import { getEndAt } from './utils/getEndAt';
+import { fmtSec } from './util/fmtSec';
 import { SkillCast } from './types';
 import TPIcon from './Pics/TP.jpg';
 
@@ -222,7 +223,7 @@ export default function App() {
     const end = maxCharges === 1
       ? Math.max(...cds.map(c => getEndAt(c, buffs)))
       : Math.min(...cds.map(c => getEndAt(c, buffs)));
-    const remaining = +(end - time).toFixed(2);
+    const remaining = fmtSec(end - time);
     return `CD ${remaining}s`;
   };
 

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildTimeline, SkillEvent } from '../lib/simulator';
+import { Buff } from '../lib/cooldown';
+
+const buffAA: Buff[] = [{ start: 0, end: 6, key: 'AA_BD' } as any];
+
+function ev(id: string, start: number, base: number): SkillEvent {
+  return { id, start, base };
+}
+
+describe('timeline recompute', () => {
+  it('scenario A: AA before FoF', () => {
+    const events = [ev('AA', 0, 30), ev('FoF', 0, 24)];
+    const tl = buildTimeline(events, buffAA);
+    expect(tl.FoF.end).toBeCloseTo(19.5, 2);
+  });
+
+  it('scenario B: insert AA later at earlier time', () => {
+    const events = [ev('FoF', 0, 24), ev('AA', 0, 30)];
+    const tl = buildTimeline(events, buffAA);
+    expect(tl.FoF.end).toBeCloseTo(19.5, 2);
+  });
+});
+
+// END_PATCH

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -1,0 +1,25 @@
+import { Buff, cdEnd } from './cooldown';
+import { cdSpeedAt, hasteAt } from '../App';
+import { SkillCast } from '../types';
+
+export interface SkillEvent extends SkillCast {}
+
+export function buildTimeline(
+  events: SkillEvent[],
+  buffs: Buff[]
+): Record<string, { start: number; end: number }> {
+  const sorted = [...events].sort((a, b) => a.start - b.start);
+  const res: Record<string, { start: number; end: number }> = {};
+  for (const ev of sorted) {
+    const speed = (t: number, bs: Buff[]) => {
+      const cdSpd = cdSpeedAt(t, bs);
+      const haste = 1 + hasteAt(t, bs);
+      return ['RSK', 'FoF', 'WU'].includes(ev.id) ? cdSpd * haste : cdSpd;
+    };
+    const end = cdEnd(ev.start, ev.base, buffs, speed);
+    res[ev.id] = { start: ev.start, end };
+  }
+  return res;
+}
+
+// END_PATCH

--- a/src/util/fmtSec.ts
+++ b/src/util/fmtSec.ts
@@ -1,0 +1,2 @@
+export const fmtSec = (v: number) => v.toFixed(2);
+// END_PATCH


### PR DESCRIPTION
## Summary
- compute cooldown timeline lazily via `buildTimeline`
- format seconds with new `fmtSec` util
- show remaining cooldown using `fmtSec`
- add tests verifying FoF cooldown when AA is inserted in any order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d6f17ac2c832facd63fe426f00449