### PR TITLE
Implement cooldown timeline hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -1,24 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { buildTimeline, SkillEvent } from '../lib/simulator';
+import { buildTimeline } from '../lib/simulator';
 import { Buff } from '../lib/cooldown';
+import { SkillCast } from '../types';
 
 const buffAA: Buff[] = [{ start: 0, end: 6, key: 'AA_BD' } as any];
 
-function ev(id: string, start: number, base: number): SkillEvent {
+function ev(id: string, start: number, base: number): SkillCast {
   return { id, start, base };
 }
 
 describe('timeline recompute', () => {
   it('scenario A: AA before FoF', () => {
-    const events = [ev('AA', 0, 30), ev('FoF', 0, 24)];
-    const tl = buildTimeline(events, buffAA);
-    expect(tl.FoF.end).toBeCloseTo(19.5, 2);
+    const casts: Record<string, SkillCast[]> = {
+      AA: [ev('AA', 0, 30)],
+      FoF: [ev('FoF', 0, 24)],
+    };
+    const tl = buildTimeline(casts, buffAA);
+    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
   });
 
   it('scenario B: insert AA later at earlier time', () => {
-    const events = [ev('FoF', 0, 24), ev('AA', 0, 30)];
-    const tl = buildTimeline(events, buffAA);
-    expect(tl.FoF.end).toBeCloseTo(19.5, 2);
+    const casts: Record<string, SkillCast[]> = {
+      FoF: [ev('FoF', 0, 24)],
+      AA: [ev('AA', 0, 30)],
+    };
+    const tl = buildTimeline(casts, buffAA);
+    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
   });
 });
 

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -1,25 +1,16 @@
-import { Buff, cdEnd } from './cooldown';
-import { cdSpeedAt, hasteAt } from '../App';
+import type { Buff } from './cooldown';
 import { SkillCast } from '../types';
-
-export interface SkillEvent extends SkillCast {}
+import { getEndAt } from '../utils/getEndAt';
 
 export function buildTimeline(
-  events: SkillEvent[],
-  buffs: Buff[]
-): Record<string, { start: number; end: number }> {
-  const sorted = [...events].sort((a, b) => a.start - b.start);
-  const res: Record<string, { start: number; end: number }> = {};
-  for (const ev of sorted) {
-    const speed = (t: number, bs: Buff[]) => {
-      const cdSpd = cdSpeedAt(t, bs);
-      const haste = 1 + hasteAt(t, bs);
-      return ['RSK', 'FoF', 'WU'].includes(ev.id) ? cdSpd * haste : cdSpd;
-    };
-    const end = cdEnd(ev.start, ev.base, buffs, speed);
-    res[ev.id] = { start: ev.start, end };
+  casts: Record<string, SkillCast[]>,
+  buffs: Buff[],
+): Record<string, { start: number; end: number }[]> {
+  const out: Record<string, { start: number; end: number }[]> = {};
+  for (const [key, recs] of Object.entries(casts)) {
+    out[key] = recs.map(c => ({ start: c.start, end: getEndAt(c, buffs) }));
   }
-  return res;
+  return out;
 }
 
 // END_PATCH

--- a/src/util/fmt.ts
+++ b/src/util/fmt.ts
@@ -1,0 +1,1 @@
+export const fmt = (v: number) => v.toFixed(2);

--- a/src/util/fmtSec.ts
+++ b/src/util/fmtSec.ts
@@ -1,2 +1,0 @@
-export const fmtSec = (v: number) => v.toFixed(2);
-// END_PATCH

--- a/tests/cd.spec.ts
+++ b/tests/cd.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getEndAt } from '../src/utils/getEndAt';
+import { SkillCast } from '../src/types';
+import type { Buff } from '../src/lib/cooldown';
+
+function b(key: string, start: number, end: number): Buff {
+  return { key, start, end } as any;
+}
+
+describe('cooldown integration', () => {
+  it('AA cooldown ends at 25.50 s with dragon', () => {
+    const buffs: Buff[] = [b('AA_BD', 0, 6)];
+    const aa: SkillCast = { id: 'AA', start: 0, base: 30 };
+    expect(getEndAt(aa, buffs)).toBeCloseTo(25.50, 2);
+  });
+
+  it('FoF ends at 19.50 s after AA', () => {
+    const buffs: Buff[] = [b('AA_BD', 0, 6)];
+    const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
+    expect(getEndAt(fof, buffs)).toBeCloseTo(19.50, 2);
+  });
+
+  it('RSK shortens after Blessing extended', () => {
+    const rsk: SkillCast = { id: 'RSK', start: 0, base: 10 };
+    const buffs1: Buff[] = [b('Blessing', 0, 4)];
+    const end1 = getEndAt(rsk, buffs1);
+    const buffs2: Buff[] = [b('Blessing', 0, 8)];
+    const end2 = getEndAt(rsk, buffs2);
+    expect(end2).toBeLessThan(end1);
+  });
+});


### PR DESCRIPTION
## Summary
- delete one-off cooldown calculations
- add reusable timeline builder
- use buildTimeline in App
- create fmt helper for consistent decimal output
- add comprehensive cooldown tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687d74aef03c832fafae64826a159d29