### PR TITLE
Implement new cdSpeedAt formula

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,24 +4,12 @@ import { wwData, WWKey } from './jobs/windwalker';
 import { ratingToHaste } from './lib/haste';
 import { getEndAt } from './utils/getEndAt';
 import { buildTimeline } from './lib/simulator';
+import { cdSpeedAt } from './lib/speed';
 import { fmt } from './util/fmt';
 import { SkillCast } from './types';
 import TPIcon from './Pics/TP.jpg';
 
 export interface BuffRec { key: string; start: number; end: number }
-
-export function cdSpeedAt(t: number, buffs: BuffRec[] = []): number {
-  const list = buffs.filter(b => t >= b.start && t < b.end).map(b => b.key);
-  const hasAA = list.includes('AA_BD');
-  const hasSW = list.includes('SW_BD');
-  const hasCC = list.includes('CC_BD');
-  let extraSpd = 0;
-  if (hasCC) extraSpd += 1.5;
-  else if (hasAA) extraSpd += 0.75;
-  if (hasSW) extraSpd += 0.75;
-  if (hasSW && (hasAA || hasCC)) extraSpd *= 1.75;
-  return 1 + extraSpd;
-}
 
 export function hasteAt(
   t: number,

--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { cdEnd } from '../lib/cooldown';
-import { cdSpeedAt, hasteAt, BuffRec } from '../App';
+import { cdSpeedAt } from '../lib/speed';
+import { hasteAt, BuffRec } from '../App';
 
 const ql: BuffRec[] = [{ key: 'AA_BD', start: 0, end: 6 }];
 

--- a/src/lib/speed.ts
+++ b/src/lib/speed.ts
@@ -1,0 +1,52 @@
+export interface Buff {
+  start: number;
+  end: number;
+  kind: 'AA' | 'CW' | 'CC' | 'BLESS';
+}
+
+function kindOf(b: any): Buff['kind'] | undefined {
+  if (b.kind) return b.kind;
+  switch (b.key) {
+    case 'AA_BD':
+      return 'AA';
+    case 'SW_BD':
+      return 'CW';
+    case 'CC_BD':
+      return 'CC';
+    case 'Blessing':
+      return 'BLESS';
+    default:
+      return undefined;
+  }
+}
+
+const active = (t: number, buffs: any[], k: Buff['kind']) =>
+  buffs.some(b => kindOf(b) === k && b.start <= t && t < b.end);
+
+const count = (t: number, buffs: any[], k: Buff['kind']) =>
+  buffs.filter(b => kindOf(b) === k && b.start <= t && t < b.end).length;
+
+export function cdSpeedAt(t: number, buffs: Buff[]): number {
+  const hasCW = active(t, buffs, 'CW');
+  const hasCC = active(t, buffs, 'CC');
+  const hasAA = active(t, buffs, 'AA');
+  const stacks = count(t, buffs, 'BLESS');
+
+  let extraOther = 0;
+  if (hasCC) extraOther = 1.5;
+  else if (hasAA) extraOther = 0.75;
+
+  let speed = 1;
+
+  if (hasCW) {
+    speed = extraOther > 0 ? 1 + extraOther * 1.75 : 1 + 0.75;
+  } else {
+    speed = 1 + extraOther;
+  }
+
+  if (stacks > 0) speed *= 1.15 * stacks;
+
+  return speed;
+}
+
+// END_PATCH

--- a/src/utils/getEndAt.ts
+++ b/src/utils/getEndAt.ts
@@ -1,10 +1,11 @@
 import { cdEnd, Buff } from '../lib/cooldown';
-import { cdSpeedAt, hasteAt } from '../App';
+import { cdSpeedAt } from '../lib/speed';
+import { hasteAt } from '../App';
 import { SkillCast } from '../types';
 
 export function getEndAt(cast: SkillCast, buffs: Buff[]): number {
   const speed = (t: number, b: Buff[]) => {
-    const cdSpd = cdSpeedAt(t, b);
+    const cdSpd = cdSpeedAt(t, b as any);
     const haste = 1 + hasteAt(t, b);
     return ['RSK', 'FoF', 'WU'].includes(cast.id) ? cdSpd * haste : cdSpd;
   };

--- a/tests/speed.spec.ts
+++ b/tests/speed.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { cdSpeedAt, Buff } from '../src/lib/speed';
+
+function b(kind: Buff['kind'], start = 0, end = 5): Buff {
+  return { kind, start, end };
+}
+
+describe('cdSpeedAt formula', () => {
+  it('scenario A: single AA', () => {
+    const buffs = [b('AA')];
+    expect(cdSpeedAt(1, buffs)).toBeCloseTo(1.75, 4);
+  });
+
+  it('scenario B: AA + CW', () => {
+    const buffs = [b('AA'), b('CW')];
+    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3125, 4);
+  });
+
+  it('scenario C: CC + CW', () => {
+    const buffs = [b('CC'), b('CW')];
+    expect(cdSpeedAt(1, buffs)).toBeCloseTo(3.625, 4);
+  });
+
+  it('scenario D: two Blessings', () => {
+    const buffs = [b('BLESS'), b('BLESS')];
+    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3, 4);
+  });
+});
+
+// END_PATCH


### PR DESCRIPTION
## Summary
- add `src/lib/speed.ts` with updated cooldown speed formula
- hook UI and helpers to new `cdSpeedAt` implementation
- update integration tests to use the new module
- add dedicated unit tests for `cdSpeedAt`
- include new test file in `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d8e4ea410832f90160d4db05c333c