### PR TITLE
Update cdSpeedAt and tests

### DIFF
--- a/src/__tests__/cooldown.spec.ts
+++ b/src/__tests__/cooldown.spec.ts
@@ -4,11 +4,11 @@ import { Buff } from '../lib/cooldown';
 import { SkillCast } from '../types';
 
 describe('cooldown lazy compute', () => {
-  it('FoF ends at 19.50\u00a0s when AA inserted before it', () => {
+  it('FoF ends at 17.925\u00a0s when AA inserted before it', () => {
     const buffs: Buff[] = [{ start: 0, end: 6, key: 'AA_BD' } as any];
     const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
     const aa: SkillCast  = { id: 'AA',  start: 0, base: 30 };
-    expect(getEndAt(fof, buffs)).toBeCloseTo(19.50, 2);
-    expect(getEndAt(aa, buffs)).toBeCloseTo(25.50, 2);
+    expect(getEndAt(fof, buffs)).toBeCloseTo(17.925, 3);
+    expect(getEndAt(aa, buffs)).toBeCloseTo(23.925, 3);
   });
 });

--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -6,13 +6,13 @@ import { hasteAt, BuffRec } from '../App';
 const ql: BuffRec[] = [{ key: 'AA_BD', start: 0, end: 6 }];
 
 describe('cdEnd integration', () => {
-  it('FoF ends at 19.5 s', () => {
+  it('FoF ends at 17.925 s', () => {
     const end = cdEnd(0, 24, ql, (t, b) => cdSpeedAt(t, b));
-    expect(end).toBeCloseTo(19.5, 1);
+    expect(end).toBeCloseTo(17.925, 3);
   });
 
-  it('AA ends at 25.5 s', () => {
+  it('AA ends at 23.925 s', () => {
     const end = cdEnd(0, 30, ql, (t, b) => cdSpeedAt(t, b) * (1 + hasteAt(t, b)));
-    expect(end).toBeCloseTo(25.5, 1);
+    expect(end).toBeCloseTo(23.925, 3);
   });
 });

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -16,7 +16,7 @@ describe('timeline recompute', () => {
       FoF: [ev('FoF', 0, 24)],
     };
     const tl = buildTimeline(casts, buffAA);
-    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
+    expect(tl.FoF[0].end).toBeCloseTo(17.925, 3);
   });
 
   it('scenario B: insert AA later at earlier time', () => {
@@ -25,7 +25,7 @@ describe('timeline recompute', () => {
       AA: [ev('AA', 0, 30)],
     };
     const tl = buildTimeline(casts, buffAA);
-    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
+    expect(tl.FoF[0].end).toBeCloseTo(17.925, 3);
   });
 });
 

--- a/src/combat/azureDragonHeart.ts
+++ b/src/combat/azureDragonHeart.ts
@@ -99,18 +99,6 @@ export class BuffManager {
   }
 }
 
-export function cdSpeedAt(manager: BuffManager, time = manager.time) {
-  const list = manager.activeDragons(time).map(b => b.kind);
-  const hasAA = list.includes('AA');
-  const hasSW = list.includes('SW');
-  const hasCC = list.includes('CC');
-  let extra = 0;
-  if (hasCC) extra += CD_SPEED.CC;
-  else if (hasAA) extra += CD_SPEED.AA;
-  if (hasSW) extra += CD_SPEED.SW;
-  if (hasSW && (hasAA || hasCC)) extra *= CD_SPEED.SW_COEXIST;
-  return 1 + extra;
-}
 
 export function fofModAt(manager: BuffManager, time = manager.time) {
   const list = manager.activeDragons(time).map(b => b.kind);

--- a/src/combat/skills.ts
+++ b/src/combat/skills.ts
@@ -1,4 +1,5 @@
-import { BuffManager, AzureDragonHeart, Blessing, cdSpeedAt, fofModAt, hasteMult } from './azureDragonHeart';
+import { BuffManager, AzureDragonHeart, Blessing, fofModAt, hasteMult } from './azureDragonHeart';
+import { cdSpeedAt } from '../lib/speed';
 import { BUFF_DURATION } from '../constants/buffs';
 
 export interface SkillOptions {

--- a/src/lib/speed.ts
+++ b/src/lib/speed.ts
@@ -1,11 +1,10 @@
-export interface Buff {
-  start: number;
-  end: number;
-  kind: 'AA' | 'CW' | 'CC' | 'BLESS';
-}
+import type { Buff } from './cooldown';
 
-function kindOf(b: any): Buff['kind'] | undefined {
-  if (b.kind) return b.kind;
+// Buff: { start:number; end:number; kind:'AA'|'CW'|'CC'|'BLESS' }
+type Kind = 'AA' | 'CW' | 'CC' | 'BLESS';
+
+function kindOf(b: any): Kind | undefined {
+  if (b.kind) return b.kind as Kind;
   switch (b.key) {
     case 'AA_BD':
       return 'AA';
@@ -20,33 +19,33 @@ function kindOf(b: any): Buff['kind'] | undefined {
   }
 }
 
-const active = (t: number, buffs: any[], k: Buff['kind']) =>
+const active = (t: number, buffs: any[], k: Kind) =>
   buffs.some(b => kindOf(b) === k && b.start <= t && t < b.end);
 
-const count = (t: number, buffs: any[], k: Buff['kind']) =>
+const count = (t: number, buffs: any[], k: Kind) =>
   buffs.filter(b => kindOf(b) === k && b.start <= t && t < b.end).length;
 
 export function cdSpeedAt(t: number, buffs: Buff[]): number {
-  const hasCW = active(t, buffs, 'CW');
-  const hasCC = active(t, buffs, 'CC');
-  const hasAA = active(t, buffs, 'AA');
-  const stacks = count(t, buffs, 'BLESS');
+  const aa = active(t, buffs, 'AA');
+  const cw = active(t, buffs, 'CW');
+  const cc = active(t, buffs, 'CC');
 
-  let extraOther = 0;
-  if (hasCC) extraOther = 1.5;
-  else if (hasAA) extraOther = 0.75;
+  let extra = 0;
+  if (cc) extra = 1.5;
+  else if (aa) extra = 0.75;
 
-  let speed = 1;
-
-  if (hasCW) {
-    speed = extraOther > 0 ? 1 + extraOther * 1.75 : 1 + 0.75;
-  } else {
-    speed = 1 + extraOther;
+  if (cw) {
+    if (cc) extra = 1.5 * 1.75;
+    else if (aa) extra = 0.75 * 1.75;
+    else extra = 0.75;
   }
 
-  if (stacks > 0) speed *= 1.15 * stacks;
+  const dragonSpeed = 1 + extra;
 
-  return speed;
+  const n =
+    count(t, buffs, 'BLESS') + (aa ? 1 : 0) + (cw ? 1 : 0) + (cc ? 1 : 0);
+
+  return dragonSpeed * Math.pow(1.15, n);
 }
 
 // END_PATCH

--- a/tests/azureDragonHeart.test.ts
+++ b/tests/azureDragonHeart.test.ts
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const { describe, it } = require('mocha');
-const { BuffManager, cdSpeedAt, fofModAt } = require('../src/combat/azureDragonHeart');
+const { BuffManager, fofModAt } = require('../src/combat/azureDragonHeart');
+const { cdSpeedAt } = require('../src/lib/speed');
 const { AA, SW, CC } = require('../src/combat/skills');
 
 function use(skill: any, time: number, mgr: any) {

--- a/tests/cd.spec.ts
+++ b/tests/cd.spec.ts
@@ -8,16 +8,16 @@ function b(key: string, start: number, end: number): Buff {
 }
 
 describe('cooldown integration', () => {
-  it('AA cooldown ends at 25.50 s with dragon', () => {
+  it('AA cooldown ends at 23.925 s with dragon', () => {
     const buffs: Buff[] = [b('AA_BD', 0, 6)];
     const aa: SkillCast = { id: 'AA', start: 0, base: 30 };
-    expect(getEndAt(aa, buffs)).toBeCloseTo(25.50, 2);
+    expect(getEndAt(aa, buffs)).toBeCloseTo(23.925, 3);
   });
 
-  it('FoF ends at 19.50 s after AA', () => {
+  it('FoF ends at 17.925 s after AA', () => {
     const buffs: Buff[] = [b('AA_BD', 0, 6)];
     const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
-    expect(getEndAt(fof, buffs)).toBeCloseTo(19.50, 2);
+    expect(getEndAt(fof, buffs)).toBeCloseTo(17.925, 3);
   });
 
   it('RSK shortens after Blessing extended', () => {

--- a/tests/speed.spec.ts
+++ b/tests/speed.spec.ts
@@ -1,30 +1,26 @@
-import { describe, it, expect } from 'vitest';
-import { cdSpeedAt, Buff } from '../src/lib/speed';
+import { expect, test } from 'vitest';
+import { cdSpeedAt } from '../src/lib/speed';
 
-function b(kind: Buff['kind'], start = 0, end = 5): Buff {
-  return { kind, start, end };
-}
+const mk = (s: number, d: number, k: string) => ({ start: s, end: s + d, kind: k });
 
-describe('cdSpeedAt formula', () => {
-  it('scenario A: single AA', () => {
-    const buffs = [b('AA')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(1.75, 4);
-  });
+test('AA only', () => {
+  const buffs = [mk(0, 6, 'AA')];
+  expect(cdSpeedAt(3, buffs)).toBeCloseTo(1.75 * 1.15, 4);
+});
 
-  it('scenario B: AA + CW', () => {
-    const buffs = [b('AA'), b('CW')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3125, 4);
-  });
+test('AA + CW', () => {
+  const buffs = [mk(0, 6, 'AA'), mk(0, 8, 'CW')];
+  expect(cdSpeedAt(2, buffs)).toBeCloseTo(2.3125 * (1.15 ** 2), 4);
+});
 
-  it('scenario C: CC + CW', () => {
-    const buffs = [b('CC'), b('CW')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(3.625, 4);
-  });
+test('CC + CW', () => {
+  const buffs = [mk(0, 6, 'CC'), mk(0, 8, 'CW')];
+  expect(cdSpeedAt(2, buffs)).toBeCloseTo(3.625 * (1.15 ** 2), 4);
+});
 
-  it('scenario D: two Blessings', () => {
-    const buffs = [b('BLESS'), b('BLESS')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3, 4);
-  });
+test('CC dominates AA', () => {
+  const buffs = [mk(0, 6, 'CC'), mk(0, 6, 'AA')];
+  expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.5 * (1.15 ** 2), 4);
 });
 
 // END_PATCH


### PR DESCRIPTION
## Summary
- implement new cdSpeedAt formula with dragon/Blessing stacking
- adjust skills and tests to use new helper
- update cooldown expectation numbers in unit tests
- remove old cdSpeedAt from azureDragonHeart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d940841ac832fb4da861462b6e353