### PR TITLE
Implement new dragon speed formula

### DIFF
--- a/src/__tests__/cooldown.spec.ts
+++ b/src/__tests__/cooldown.spec.ts
@@ -8,7 +8,7 @@ describe('cooldown lazy compute', () => {
     const buffs: Buff[] = [{ start: 0, end: 6, key: 'AA_BD' } as any];
     const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
     const aa: SkillCast  = { id: 'AA',  start: 0, base: 30 };
-    expect(getEndAt(fof, buffs)).toBeCloseTo(19.50, 2);
-    expect(getEndAt(aa, buffs)).toBeCloseTo(25.50, 2);
+    expect(getEndAt(fof, buffs)).toBeCloseTo(17.93, 2);
+    expect(getEndAt(aa, buffs)).toBeCloseTo(23.93, 2);
   });
 });

--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -8,11 +8,11 @@ const ql: BuffRec[] = [{ key: 'AA_BD', start: 0, end: 6 }];
 describe('cdEnd integration', () => {
   it('FoF ends at 19.5 s', () => {
     const end = cdEnd(0, 24, ql, (t, b) => cdSpeedAt(t, b));
-    expect(end).toBeCloseTo(19.5, 1);
+    expect(end).toBeCloseTo(17.93, 1);
   });
 
   it('AA ends at 25.5 s', () => {
     const end = cdEnd(0, 30, ql, (t, b) => cdSpeedAt(t, b) * (1 + hasteAt(t, b)));
-    expect(end).toBeCloseTo(25.5, 1);
+    expect(end).toBeCloseTo(23.93, 1);
   });
 });

--- a/src/__tests__/timeline.test.ts
+++ b/src/__tests__/timeline.test.ts
@@ -9,23 +9,23 @@ function ev(id: string, start: number, base: number): SkillCast {
   return { id, start, base };
 }
 
-describe('timeline recompute', () => {
-  it('scenario A: AA before FoF', () => {
+  describe('timeline recompute', () => {
+    it('scenario A: AA before FoF', () => {
     const casts: Record<string, SkillCast[]> = {
       AA: [ev('AA', 0, 30)],
       FoF: [ev('FoF', 0, 24)],
     };
     const tl = buildTimeline(casts, buffAA);
-    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
+    expect(tl.FoF[0].end).toBeCloseTo(17.93, 2);
   });
 
-  it('scenario B: insert AA later at earlier time', () => {
+    it('scenario B: insert AA later at earlier time', () => {
     const casts: Record<string, SkillCast[]> = {
       FoF: [ev('FoF', 0, 24)],
       AA: [ev('AA', 0, 30)],
     };
     const tl = buildTimeline(casts, buffAA);
-    expect(tl.FoF[0].end).toBeCloseTo(19.5, 2);
+    expect(tl.FoF[0].end).toBeCloseTo(17.93, 2);
   });
 });
 

--- a/src/lib/speed.ts
+++ b/src/lib/speed.ts
@@ -27,26 +27,29 @@ const count = (t: number, buffs: any[], k: Buff['kind']) =>
   buffs.filter(b => kindOf(b) === k && b.start <= t && t < b.end).length;
 
 export function cdSpeedAt(t: number, buffs: Buff[]): number {
-  const hasCW = active(t, buffs, 'CW');
-  const hasCC = active(t, buffs, 'CC');
-  const hasAA = active(t, buffs, 'AA');
-  const stacks = count(t, buffs, 'BLESS');
+  const aa = active(t, buffs, 'AA');
+  const cw = active(t, buffs, 'CW');
+  const cc = active(t, buffs, 'CC');
 
-  let extraOther = 0;
-  if (hasCC) extraOther = 1.5;
-  else if (hasAA) extraOther = 0.75;
+  let extra = 0;
+  if (cc) extra = 1.5;
+  else if (aa) extra = 0.75;
 
-  let speed = 1;
-
-  if (hasCW) {
-    speed = extraOther > 0 ? 1 + extraOther * 1.75 : 1 + 0.75;
-  } else {
-    speed = 1 + extraOther;
+  if (cw) {
+    if (cc) extra = 1.5 * 1.75;
+    else if (aa) extra = 0.75 * 1.75;
+    else extra = 0.75;
   }
 
-  if (stacks > 0) speed *= 1.15 * stacks;
+  const dragonSpeed = 1 + extra;
 
-  return speed;
+  const n =
+    count(t, buffs, 'BLESS') +
+    (aa ? 1 : 0) +
+    (cw ? 1 : 0) +
+    (cc ? 1 : 0);
+
+  return dragonSpeed * Math.pow(1.15, n);
 }
 
 // END_PATCH

--- a/tests/cd.spec.ts
+++ b/tests/cd.spec.ts
@@ -11,13 +11,13 @@ describe('cooldown integration', () => {
   it('AA cooldown ends at 25.50 s with dragon', () => {
     const buffs: Buff[] = [b('AA_BD', 0, 6)];
     const aa: SkillCast = { id: 'AA', start: 0, base: 30 };
-    expect(getEndAt(aa, buffs)).toBeCloseTo(25.50, 2);
+    expect(getEndAt(aa, buffs)).toBeCloseTo(23.93, 2);
   });
 
   it('FoF ends at 19.50 s after AA', () => {
     const buffs: Buff[] = [b('AA_BD', 0, 6)];
     const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
-    expect(getEndAt(fof, buffs)).toBeCloseTo(19.50, 2);
+    expect(getEndAt(fof, buffs)).toBeCloseTo(17.93, 2);
   });
 
   it('RSK shortens after Blessing extended', () => {

--- a/tests/speed.spec.ts
+++ b/tests/speed.spec.ts
@@ -1,30 +1,26 @@
-import { describe, it, expect } from 'vitest';
-import { cdSpeedAt, Buff } from '../src/lib/speed';
+import { expect, test } from 'vitest';
+import { cdSpeedAt } from '../src/lib/speed';
 
-function b(kind: Buff['kind'], start = 0, end = 5): Buff {
-  return { kind, start, end };
-}
+const mk = (s: number, d: number, k: string) => ({ start: s, end: s + d, kind: k } as any);
 
-describe('cdSpeedAt formula', () => {
-  it('scenario A: single AA', () => {
-    const buffs = [b('AA')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(1.75, 4);
-  });
+test('AA only', () => {
+  const buffs = [mk(0, 6, 'AA')];
+  expect(cdSpeedAt(3, buffs)).toBeCloseTo(1.75 * 1.15, 4);
+});
 
-  it('scenario B: AA + CW', () => {
-    const buffs = [b('AA'), b('CW')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3125, 4);
-  });
+test('AA + CW', () => {
+  const buffs = [mk(0, 6, 'AA'), mk(0, 8, 'CW')];
+  expect(cdSpeedAt(2, buffs)).toBeCloseTo(2.3125 * (1.15 ** 2), 4);
+});
 
-  it('scenario C: CC + CW', () => {
-    const buffs = [b('CC'), b('CW')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(3.625, 4);
-  });
+test('CC + CW', () => {
+  const buffs = [mk(0, 6, 'CC'), mk(0, 8, 'CW')];
+  expect(cdSpeedAt(2, buffs)).toBeCloseTo(3.625 * (1.15 ** 2), 4);
+});
 
-  it('scenario D: two Blessings', () => {
-    const buffs = [b('BLESS'), b('BLESS')];
-    expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.3, 4);
-  });
+test('CC dominates AA', () => {
+  const buffs = [mk(0, 6, 'CC'), mk(0, 6, 'AA')];
+  expect(cdSpeedAt(1, buffs)).toBeCloseTo(2.5 * (1.15 ** 2), 4);
 });
 
 // END_PATCH


### PR DESCRIPTION
## Summary
- overhaul `cdSpeedAt` logic to correctly combine dragon and blessing effects
- update tests for new speed formula

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d940841ac832fb4da861462b6e353