### PR TITLE
feat(haste): haste multiplier system, Bloodlust buff, debug lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/combat/azureDragonHeart.ts
+++ b/src/combat/azureDragonHeart.ts
@@ -7,6 +7,7 @@ import {
   FOF_SPEED,
   DragonType,
 } from '../constants/buffs';
+import { ratingToHaste } from '../lib/haste';
 
 export class Blessing extends Buff {
   stacks = 1;
@@ -30,9 +31,16 @@ export class AzureDragonHeart extends Buff {
   }
 }
 
+export class Bloodlust extends Buff {
+  constructor(start: number) {
+    super('BL', start, 40, 1.3);
+  }
+}
+
 export class BuffManager {
   private buffs: Buff[] = [];
   time = 0;
+  constructor(public hasteRating = 0) {}
 
   advance(to: number) {
     this.time = to;
@@ -123,6 +131,9 @@ export function fofModAt(manager: BuffManager, time = manager.time) {
 }
 
 export function hasteMult(manager: BuffManager, time = manager.time) {
-  const blessing = manager.blessing(time);
-  return blessing ? blessing.hasteMult : 1;
+  const gear = 1 + ratingToHaste(manager.hasteRating);
+  const buffs = manager
+    .activeBuffs(time)
+    .reduce((m, b) => m * (b.hasteMult ?? 1), 1);
+  return gear * buffs;
 }

--- a/src/combat/buff.ts
+++ b/src/combat/buff.ts
@@ -6,6 +6,8 @@ export class Buff extends EventEmitter {
     public name: string,
     public start: number,
     public duration: number,
+    /** multiplicative haste bonus (1 = no haste) */
+    public hasteMult = 1,
   ) {
     super();
   }

--- a/src/combat/skills.ts
+++ b/src/combat/skills.ts
@@ -1,4 +1,4 @@
-import { BuffManager, AzureDragonHeart, Blessing, cdSpeedAt, fofModAt, hasteMult } from './azureDragonHeart';
+import { BuffManager, AzureDragonHeart, Blessing, Bloodlust, cdSpeedAt, fofModAt, hasteMult } from './azureDragonHeart';
 import { BUFF_DURATION } from '../constants/buffs';
 
 export interface SkillOptions {
@@ -29,6 +29,8 @@ export class Skill {
       const start = time + cast;
       manager.add(new AzureDragonHeart('CC', start));
       manager.add(new Blessing(start));
+    } else if (this.opts.name === 'BL') {
+      manager.add(new Bloodlust(time + cast));
     }
     manager.advance(time); // ensure expiration check upto now
     return { cd, cast };
@@ -41,3 +43,4 @@ export const CC = new Skill({ name: 'CC', baseCd: 90, cast: 4 });
 export const FoF = new Skill({ name: 'FoF', baseCd: 24, cast: 4, hasted: true });
 export const RSK = new Skill({ name: 'RSK', baseCd: 10, hasted: true });
 export const WU = new Skill({ name: 'WU', baseCd: 25, hasted: true });
+export const BL = new Skill({ name: 'BL', baseCd: 60 });

--- a/src/lib/haste.ts
+++ b/src/lib/haste.ts
@@ -36,3 +36,24 @@ export function effTime(base: number, hastePct: number, floor = 0.75) {
   const t = base / (1 + hastePct);
   return base === 1 ? 1 : Math.max(t, floor); // 踏风 GCD 固定 1
 }
+
+export interface BuffEvent {
+  id: string;
+  name: string;
+  startMs: number;
+  endMs: number;
+  multiplier: number;
+  type: 'buff';
+}
+
+export function totalHasteAt(
+  rating: number,
+  buffs: BuffEvent[],
+  t: number,
+): number {
+  const gear = 1 + ratingToHaste(rating);
+  const buffMult = buffs
+    .filter(b => b.startMs <= t && t < b.endMs)
+    .reduce((m, b) => m * b.multiplier, 1);
+  return gear * buffMult;
+}

--- a/tests/cdSnapshot.spec.ts
+++ b/tests/cdSnapshot.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { BuffManager, Bloodlust } from '../src/combat/azureDragonHeart';
+import { FoF } from '../src/combat/skills';
+
+// FoF base CD is 24s. With gear haste 20% and BL 30% => total 1.56 multiplier
+
+describe('cooldown snapshot', () => {
+  it('FoF under bloodlust uses haste at cast time', () => {
+    const mgr = new BuffManager(13200); // 20% gear
+    mgr.add(new Bloodlust(0));
+    const { cd } = FoF.use(0, mgr);
+    expect(cd * 1000).toBeCloseTo(24000 / 1.56, 1);
+  });
+});

--- a/tests/haste.spec.ts
+++ b/tests/haste.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { totalHasteAt, BuffEvent } from '../src/lib/haste';
+
+describe('totalHasteAt', () => {
+  const rating = 13200; // 20% gear haste
+
+  it('gear only', () => {
+    const h = totalHasteAt(rating, [], 0);
+    expect(h).toBeCloseTo(1.2, 2);
+  });
+
+  it('with Bloodlust', () => {
+    const buffs: BuffEvent[] = [{
+      id: 'BL',
+      name: 'Bloodlust',
+      startMs: 0,
+      endMs: 40000,
+      multiplier: 1.3,
+      type: 'buff',
+    }];
+    const h = totalHasteAt(rating, buffs, 1000);
+    expect(h).toBeCloseTo(1.2 * 1.3, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add BuffEvent model and totalHasteAt helper
- introduce Bloodlust buff and haste multiplier logic
- support gear haste via BuffManager
- add Bloodlust skill and cooldown snapshot test
- update test script and add new unit tests

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68803ae20cd8832faf3f016a66270363