### PR TITLE
feat(haste): haste multiplier system, Bloodlust buff, debug lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/__tests__/cooldown.test.ts
+++ b/src/__tests__/cooldown.test.ts
@@ -12,7 +12,7 @@ describe('cdEnd integration', () => {
   });
 
   it('AA ends at 25.5 s', () => {
-    const end = cdEnd(0, 30, ql, (t, b) => cdSpeedAt(t, b) * (1 + hasteAt(t, b)));
+    const end = cdEnd(0, 30, ql, (t, b) => cdSpeedAt(t, b) * hasteAt(t, b));
     expect(end).toBeCloseTo(25.5, 1);
   });
 });

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -21,6 +21,7 @@ import { t } from '../i18n/en';
 import { GUIDE_COLOR } from '../constants/colors';
 
 const groups = [
+  'Haste',
   t('Boss技能'),
   t('祝福'),
   t('青龙之心'),

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -7,6 +7,7 @@ import CC from '../assets/abilityIcons/inv_ability_conduitofthecelestialsmonk_ce
 import AA from '../assets/abilityIcons/inv_hand_1h_artifactskywall_d_01.jpg';
 import SEF from '../assets/abilityIcons/spell_nature_giftofthewild.jpg';
 import FoF from '../assets/abilityIcons/monk_ability_fistoffury.jpg';
+import BL from '../assets/abilityIcons/ability_monk_risingsunkick.jpg';
 
 export const ABILITY_ICON_MAP: Record<string, {src: string; abbr: string}> = {
   WU:  {src: WU,  abbr: 'WU'},
@@ -18,4 +19,5 @@ export const ABILITY_ICON_MAP: Record<string, {src: string; abbr: string}> = {
   AA:  {src: AA,  abbr:'AA'},
   SEF: {src: SEF, abbr: 'SEF'},
   FoF: {src: FoF, abbr: 'FoF'},
+  BL:  {src: BL,  abbr: 'BL'},
 };

--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -288,4 +288,14 @@
     "gcd": 1,
     "cooldown": 90
   }
+  ,
+  {
+    "name": "Bloodlust",
+    "id": 999998,
+    "effects": [
+      {}
+    ],
+    "gcd": 1,
+    "cooldown": 90
+  }
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,12 @@ body.light {
   border-color: rgba(0, 128, 0, 0.5);
 }
 
+.vis-item.haste {
+  background-color: #001C55;
+  border-color: #001C55;
+  color: #fff;
+}
+
 .vis-item.event-guide {
   background-color: #003377;
   border-color: #003377;

--- a/src/jobs/windwalker.ts
+++ b/src/jobs/windwalker.ts
@@ -11,6 +11,7 @@ export const WW = {
   BOK: 100784,
   RSK: 107428,
   FoF: 113656,
+  BL: 999998,
 } as const;
 
 export type WWKey = keyof typeof WW;

--- a/src/lib/simulator.ts
+++ b/src/lib/simulator.ts
@@ -5,10 +5,11 @@ import { getEndAt } from '../utils/getEndAt';
 export function buildTimeline(
   casts: Record<string, SkillCast[]>,
   buffs: Buff[],
+  hasteRating = 0,
 ): Record<string, { start: number; end: number }[]> {
   const out: Record<string, { start: number; end: number }[]> = {};
   for (const [key, recs] of Object.entries(casts)) {
-    out[key] = recs.map(c => ({ start: c.start, end: getEndAt(c, buffs) }));
+    out[key] = recs.map(c => ({ start: c.start, end: getEndAt(c, buffs, hasteRating) }));
   }
   return out;
 }

--- a/src/utils/getEndAt.ts
+++ b/src/utils/getEndAt.ts
@@ -3,11 +3,10 @@ import { cdSpeedAt } from '../lib/speed';
 import { hasteAt } from '../App';
 import { SkillCast } from '../types';
 
-export function getEndAt(cast: SkillCast, buffs: Buff[]): number {
-  const speed = (t: number, b: Buff[]) => {
-    const cdSpd = cdSpeedAt(t, b as any);
-    const haste = 1 + hasteAt(t, b);
-    return ['RSK', 'FoF', 'WU'].includes(cast.id) ? cdSpd * haste : cdSpd;
-  };
-  return cdEnd(cast.start, cast.base, buffs, speed);
+export function getEndAt(cast: SkillCast, buffs: Buff[], hasteRating = 0): number {
+  if (['RSK', 'FoF', 'WU'].includes(cast.id)) {
+    const base = cast.base / hasteAt(cast.start, buffs, hasteRating);
+    return cdEnd(cast.start, base, buffs, (t, b) => cdSpeedAt(t, b as any));
+  }
+  return cdEnd(cast.start, cast.base, buffs, (t, b) => cdSpeedAt(t, b as any));
 }

--- a/tests/cdSnapshot.spec.ts
+++ b/tests/cdSnapshot.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { getEndAt } from '../src/utils/getEndAt';
+import { SkillCast } from '../src/types';
+import type { Buff } from '../src/lib/cooldown';
+
+const rating = 13200; // 20% gear haste
+const bl: Buff = { key: 'BL', start: 0, end: 40000, multiplier: 1.3 } as any;
+
+describe('snapshot cooldown', () => {
+  it('FoF under bloodlust snapshots haste', () => {
+    const cast: SkillCast = { id: 'FoF', start: 0, base: 24 };
+    const end = getEndAt(cast, [bl], rating);
+    expect(end * 1000).toBeCloseTo(24000 / 1.56, 1);
+  });
+});

--- a/tests/haste.spec.ts
+++ b/tests/haste.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { hasteAt, BuffRec } from '../src/App';
+
+describe('haste multiplier', () => {
+  const rating = 13200; // 20% haste
+  it('gear only', () => {
+    expect(hasteAt(0, [], rating)).toBeCloseTo(1.2, 2);
+  });
+  it('gear plus bloodlust', () => {
+    const bl: BuffRec = { key: 'BL', start: 0, end: 40000, multiplier: 1.3 };
+    expect(hasteAt(1000, [bl], rating)).toBeCloseTo(1.56, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- implement total haste multiplier with buffs
- snapshot haste for FoF/WU/RSK cooldowns
- add Bloodlust ability and icon
- render haste debug lane in timeline
- update tests for haste logic

## Testing
- `pnpm install`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68803ae20cd8832faf3f016a66270363