### PR TITLE
Add Blessing buff system

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,12 @@ body.light {
   color: #fff;
 }
 
+.vis-item.blessing {
+  background-color: #004400;
+  border-color: #004400;
+  color: #fff;
+}
+
 .vis-item.event-guide {
   background-color: #003377;
   border-color: #003377;


### PR DESCRIPTION
## Summary
- implement Blessing stack generation from dragon buffs
- show Blessing blocks on a new timeline row
- include Blessing in haste calculations

## Testing
- `pnpm run test`
- `pnpm install`
- `pnpm run dev` *(fails: exit 143 because server was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68812c132bac832f8e0d1c3792ed09b1