### PR TITLE
Improve timeline readability

### DIFF
--- a/src/features/timeline/AbilityBlock.tsx
+++ b/src/features/timeline/AbilityBlock.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const ICON_SIZE = 20;
+
+interface Props {
+  startPx: number;
+  icon: string;
+}
+
+export const AbilityBlock = ({ startPx, icon }: Props) => {
+  // icon position aligns with the cast time without centering offset
+  const iconX = startPx;
+  return (
+    <image href={icon} x={iconX} y={0} width={ICON_SIZE} height={ICON_SIZE} />
+  );
+};

--- a/src/features/timeline/BlessingRow.tsx
+++ b/src/features/timeline/BlessingRow.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+export interface BlessingSegment {
+  startMs: number;
+  endMs: number;
+  startPx: number;
+  widthPx: number;
+  stacks: number;
+}
+
+export function selectBlessingStacks(segments: { startMs: number; endMs: number }[], timeMs: number): number {
+  return segments.filter(s => s.startMs <= timeMs && timeMs < s.endMs).length;
+}
+
+interface Props {
+  segments: BlessingSegment[];
+  rowMidY: number;
+}
+
+export const BlessingRow = ({ segments, rowMidY }: Props) => (
+  <g>
+    {segments.map((seg, i) => (
+      <g key={i}>
+        <rect
+          x={seg.startPx}
+          y={rowMidY - 6}
+          width={seg.widthPx}
+          height={12}
+          fill="#008800"
+        />
+        {seg.widthPx >= 24 && (
+          <text
+            x={seg.startPx + 2}
+            y={rowMidY + 4}
+            fontSize={11}
+            fontWeight="bold"
+            fill="#ffffff"
+            pointerEvents="none"
+          >
+            {`${seg.stacks}×`}
+          </text>
+        )}
+      </g>
+    ))}
+  </g>
+);
+

--- a/tests/blessing.spec.tsx
+++ b/tests/blessing.spec.tsx
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { BuffManager, hasteMult } from '../src/combat/azureDragonHeart';
 import { CC, SW } from '../src/combat/skills';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { BlessingRow, selectBlessingStacks } from '../src/features/timeline/BlessingRow';
 
 function use(skill:any, t:number, mgr:BuffManager) {
   skill.use(t, mgr);
@@ -26,5 +29,25 @@ describe('Blessing stacks', () => {
     const sw = stacksAt10.find(b => b.source === 'SW');
     expect(sw && Math.abs(sw.end - 17.4) < 0.001).toBe(true);
     expect(hasteMult(mgr, 10)).toBeCloseTo(Math.pow(1.15, 2), 2);
+  });
+
+  it('overlay text shows stack count', () => {
+    const segs = [
+      { startMs: 0, endMs: 4000 },
+      { startMs: 0, endMs: 4000 },
+      { startMs: 0, endMs: 4000 },
+    ];
+    const segments = segs.map(s => ({
+      ...s,
+      startPx: 0,
+      widthPx: 30,
+      stacks: selectBlessingStacks(segs, s.startMs),
+    }));
+    const svg = renderToStaticMarkup(
+      <svg>
+        <BlessingRow segments={segments} rowMidY={5} />
+      </svg>,
+    );
+    expect(svg.includes('3×')).toBe(true);
   });
 });

--- a/tests/render_skill.spec.ts
+++ b/tests/render_skill.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AbilityBlock } from '../src/features/timeline/AbilityBlock';
+
+describe('AbilityBlock', () => {
+  it('left aligned icon', () => {
+    const out = renderToStaticMarkup(
+      <svg>
+        <AbilityBlock icon="test.png" startPx={50} />
+      </svg>
+    );
+    expect(out).toContain('x="50"');
+  });
+});


### PR DESCRIPTION
## Summary
- show stack count overlay on Blessing segments
- ensure ability icons align with cast time
- add test coverage for Blessing overlay and AbilityBlock

## Testing
- `pnpm run dev`
- `pnpm run test`
- `pnpm run cypress` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68813272ea10832f90892590a7f68932