### PR TITLE
Fix timeline icon alignment

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -114,6 +114,7 @@ export const Timeline = ({
       {
         stack: false,
         height: "400px",
+        align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),
         editable: { updateTime: true },


### PR DESCRIPTION
## Summary
- left-align ability icons in timeline

## Testing
- `pnpm run dev` *(fails: dev server interrupted after start)*
- `pnpm run test`
- `pnpm run cypress` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881a4bdb3f8832fa2a3301ce24e65bc