### PR TITLE
Fix Blessing haste precision and add tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,13 +315,15 @@ export default function App() {
       const s = times[i];
       const e = times[i + 1];
       const mult = hasteAt((s + e) / 2, all, stats.haste);
+      const label = `${mult.toFixed(3).replace(/0+$/,'').replace(/\.$/,'')}×`;
       res.push({
         id: 20000 + i,
         group: 1,
         start: s,
         end: e,
-        label: `${mult.toFixed(2)}×`,
+        label,
         className: 'haste',
+        title: label,
       });
     }
     return res;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -11,6 +11,7 @@ export interface TLItem {
   start: number; // start time in seconds
   end?: number; // optional end time in seconds
   label: string;
+  title?: string;
   stacks?: number;
   ability?: string; // ability key, used for editing
   className?: string;
@@ -189,6 +190,7 @@ export const Timeline = ({
         id: it.id,
         group: it.group,
         content: it.label,
+        title: it.title,
         start: new Date(it.start * 1000),
         end: it.end ? new Date(it.end * 1000) : undefined,
         type: it.end ? "range" : "box",

--- a/tests/blessing_haste.spec.ts
+++ b/tests/blessing_haste.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { BuffManager, hasteMult } from '../src/combat/azureDragonHeart';
+import { CC, SW, AA } from '../src/combat/skills';
+import { hasteAt } from '../src/lib/haste';
+import { getEndAt } from '../src/utils/getEndAt';
+import type { Buff } from '../src/lib/cooldown';
+import { SkillCast } from '../src/types';
+
+function use(skill: any, t: number, mgr: BuffManager) {
+  skill.use(t, mgr);
+}
+
+describe('blessing haste precision', () => {
+  it('calculates correct blessing haste', () => {
+    const mgr = new BuffManager();
+    use(CC, 0, mgr);      // CC starts at 4s
+    mgr.advance(5);
+    use(SW, 5, mgr);      // SW starts at 5.4s
+    mgr.advance(6);
+    expect(hasteMult(mgr, 6)).toBeCloseTo(Math.pow(1.15, 2), 5);
+    use(AA, 6, mgr);      // AA starts at 6s
+    mgr.advance(10);
+    expect(hasteMult(mgr, 10)).toBeCloseTo(Math.pow(1.15, 3), 5);
+  });
+
+  it('FoF cd uses un-rounded total haste', () => {
+    const rating = 13200; // 20% gear haste
+    const bl: Buff = { key: 'BL', start: 0, end: 40000, multiplier: 1.3 } as any;
+    const b1: Buff = { key: 'BLG', start: 0, end: 40000, multiplier: 1.15 } as any;
+    const b2: Buff = { key: 'BLG', start: 0, end: 40000, multiplier: 1.15 } as any;
+    const total = hasteAt(0, [bl, b1, b2], rating);
+    const cast: SkillCast = { id: 'FoF', start: 0, base: 24 / total };
+    const end = getEndAt(cast, [bl, b1, b2]);
+    expect(end * 1000).toBeCloseTo(24000 / total, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- display haste multiplier in timeline with 3-digit precision
- expose tooltip titles for timeline items
- add tests for blessing haste precision and cooldown calculation

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6881a9284538832f88e04ac045da9783