### PR TITLE
Fix precise Blessing haste multiplier

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,13 +315,15 @@ export default function App() {
       const s = times[i];
       const e = times[i + 1];
       const mult = hasteAt((s + e) / 2, all, stats.haste);
+      const lbl = `${mult.toFixed(3).replace(/0+$/,'').replace(/\.$/,'')}×`;
       res.push({
         id: 20000 + i,
         group: 1,
         start: s,
         end: e,
-        label: `${mult.toFixed(2)}×`,
+        label: lbl,
         className: 'haste',
+        title: lbl,
       });
     }
     return res;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -16,6 +16,7 @@ export interface TLItem {
   className?: string;
   pendingDelete?: boolean;
   type?: string;
+  title?: string;
 }
 
 import { t } from '../i18n/en';
@@ -194,6 +195,7 @@ export const Timeline = ({
         type: it.end ? "range" : "box",
         className: [it.className, it.type === 'guide' ? 'event-guide' : ''].filter(Boolean).join(' '),
         ...(it.stacks ? { stacks: it.stacks } : {}),
+        ...(it.title ? { title: it.title } : {}),
         style: it.type === 'guide' ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#fff` : undefined,
       })),
     );

--- a/src/lib/haste.ts
+++ b/src/lib/haste.ts
@@ -1,3 +1,4 @@
+import { BLESSING_HASTE } from '../constants/buffs';
 /** 单个阶梯常量 */
 const STEP = 6600;          // rating
 const BASE_CONV = 660;      // 660 rating = 1% haste
@@ -54,4 +55,25 @@ export function hasteAt(t: number, buffs: HasteBuff[] = [], rating = 0): number 
     .filter(b => t >= b.start && t < b.end)
     .reduce((p, b) => p * (b.multiplier ?? 1), 1);
   return gear * mult;
+}
+
+export function selectBlessingHaste(buffs: HasteBuff[], t: number) {
+  const stacks = buffs.filter(b =>
+    b.multiplier === BLESSING_HASTE && t >= b.start && t < b.end
+  ).length;
+  return Math.pow(BLESSING_HASTE, stacks);
+}
+
+export function selectBloodlustHaste(buffs: HasteBuff[], t: number) {
+  const bl = buffs.find(b => b.multiplier === 1.3 && t >= b.start && t < b.end);
+  return bl?.multiplier ?? 1;
+}
+
+export function selectTotalHasteAt(
+  buffs: HasteBuff[],
+  rating: number,
+  t: number,
+) {
+  const gear = 1 + ratingToHaste(rating);
+  return gear * selectBloodlustHaste(buffs, t) * selectBlessingHaste(buffs, t);
 }

--- a/tests/blessing_haste.spec.ts
+++ b/tests/blessing_haste.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { selectBlessingHaste, selectTotalHasteAt } from '../src/lib/haste';
+import { getEndAt } from '../src/utils/getEndAt';
+import type { Buff } from '../src/lib/cooldown';
+
+function b(start: number, end: number): Buff {
+  return { start, end, multiplier: 1.15 } as any;
+}
+
+describe('blessing haste precision', () => {
+  it('calculates correct blessing haste', () => {
+    const buffs: Buff[] = [b(0, 5000), b(0, 5000)];
+    expect(selectBlessingHaste(buffs as any, 1000)).toBeCloseTo(Math.pow(1.15, 2), 5);
+    buffs.push(b(1500, 5500));
+    expect(selectBlessingHaste(buffs as any, 2000)).toBeCloseTo(Math.pow(1.15, 3), 5);
+  });
+
+  it('FoF cd uses un-rounded total haste', () => {
+    const rating = 13200; // +20% gear haste
+    const bl: Buff = { start: 0, end: 40000, multiplier: 1.3 } as any;
+    const blessings: Buff[] = [b(0, 5000), b(0, 5000)];
+    const all = [bl, ...blessings];
+    const haste = selectTotalHasteAt(all as any, rating, 1000);
+    const cast = { id: 'FoF', start: 0, base: 24 / haste };
+    const end = getEndAt(cast, all as any);
+    expect(end * 1000).toBeCloseTo(24000 / haste, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- keep full precision for Blessing haste math
- display haste values with three decimals
- show haste multiplier tooltip
- add regression tests for Blessing haste precision

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6881a9284538832f88e04ac045da9783