### PR TITLE
Implement dynamic cooldown sweep with dragon overlap

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -1,0 +1,21 @@
+export interface Ability {
+  id: string;
+  cooldownMs: number;
+  snapshot?: boolean;
+}
+
+export const ABILITIES: Record<string, Ability> = {
+  AA: { id: 'AA', cooldownMs: 30000 },
+  SW: { id: 'SW', cooldownMs: 30000 },
+  YH: { id: 'YH', cooldownMs: 30000 },
+  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true },
+  RSK: { id: 'RSK', cooldownMs: 10000, snapshot: true },
+  WU: { id: 'WU', cooldownMs: 25000, snapshot: true },
+  BL: { id: 'BL', cooldownMs: 0 },
+};
+
+export function abilityById(id: string): Ability {
+  const a = ABILITIES[id];
+  if (!a) throw new Error(`unknown ability ${id}`);
+  return a;
+}

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,0 +1,78 @@
+import { abilityById } from '../constants/abilities';
+import { selectTotalHasteAt as hasteAt, HasteBuff } from '../lib/haste';
+
+export interface Buff extends HasteBuff { key: string }
+
+export interface CooldownRec {
+  abilityId: string;
+  remainingMs: number;
+  snapshot: boolean;
+}
+
+export interface RootState {
+  now: number;
+  gearRating: number;
+  buffs: Buff[];
+  active: CooldownRec[];
+}
+
+export function createState(gearRating = 0): RootState {
+  return { now: 0, gearRating, buffs: [], active: [] };
+}
+
+export function buffActive(state: RootState, key: string, t: number) {
+  return state.buffs.some(b => b.key === key && b.start <= t && t < b.end);
+}
+
+export function dragonsOverlap(state: RootState, t: number) {
+  return buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
+}
+
+export function selectTotalHasteAt(state: RootState, t: number) {
+  return hasteAt(state.buffs, state.gearRating, t);
+}
+
+export function getEffectiveTickRate(
+  state: RootState,
+  abilityId: string,
+  now: number,
+): number {
+  const ability = abilityById(abilityId);
+  if (ability.snapshot) return 1;
+  const base = selectTotalHasteAt(state, now);
+  const sync = dragonsOverlap(state, now) ? 1.8 : 0;
+  return Math.max(base, sync);
+}
+
+export function advanceTime(state: RootState, dt: number) {
+  const now = state.now + dt;
+  for (const cd of state.active) {
+    const rate = getEffectiveTickRate(state, cd.abilityId, now);
+    cd.remainingMs = Math.max(0, cd.remainingMs - dt * rate);
+  }
+  state.buffs = state.buffs.filter(b => b.end > now);
+  state.now = now;
+}
+
+export function cast(state: RootState, abilityId: string) {
+  const ability = abilityById(abilityId);
+  if (abilityId === 'AA') {
+    state.buffs.push({ key: 'AA', start: state.now, end: state.now + 6000 });
+  } else if (abilityId === 'SW') {
+    state.buffs.push({ key: 'SW', start: state.now, end: state.now + 8000 });
+  } else if (abilityId === 'BL') {
+    state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
+  }
+  if (ability.cooldownMs > 0) {
+    const rem = ability.snapshot
+      ? ability.cooldownMs / selectTotalHasteAt(state, state.now)
+      : ability.cooldownMs;
+    const existing = state.active.find(c => c.abilityId === abilityId);
+    if (existing) existing.remainingMs = rem;
+    else state.active.push({ abilityId, remainingMs: rem, snapshot: !!ability.snapshot });
+  }
+}
+
+export function getCooldown(state: RootState, abilityId: string) {
+  return state.active.find(c => c.abilityId === abilityId);
+}

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createState, cast, advanceTime, getCooldown, selectTotalHasteAt } from '../src/logic/dynamicEngine';
+
+let state: ReturnType<typeof createState>;
+
+beforeEach(() => {
+  state = createState();
+});
+
+it('AA+SW overlap sweeps 1.8s per s', () => {
+  cast(state, 'AA');
+  cast(state, 'SW');
+  cast(state, 'YH');
+  advanceTime(state, 5000);
+  expect(getCooldown(state, 'YH')!.remainingMs).toBeCloseTo(30000 - 5000 * 1.8, 0);
+});
+
+it('haste added mid-cd accelerates', () => {
+  cast(state, 'YH');
+  advanceTime(state, 5000);
+  cast(state, 'BL');
+  advanceTime(state, 5000);
+  expect(getCooldown(state, 'YH')!.remainingMs).toBeCloseTo(25000 - 5000 * 1.3, 0);
+});
+
+it('snapshot skills ignore retro haste', () => {
+  const initialHaste = selectTotalHasteAt(state, state.now);
+  cast(state, 'FoF');
+  advanceTime(state, 2000);
+  cast(state, 'BL');
+  advanceTime(state, 2000);
+  expect(getCooldown(state, 'FoF')!.remainingMs).toBeCloseTo(24000 / initialHaste - 4000, 0);
+});


### PR DESCRIPTION
## Summary
- add ability definitions with snapshot flags
- implement dynamic cooldown engine with Dragon-Sync sweep
- run new tests for cooldown sweep behaviour
- include new test file in npm scripts

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68823dcfc310832fa2e60900589d6f06