### PR TITLE
Implement dynamic cooldown engine with Dragon Sync

### DIFF
--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -1,0 +1,21 @@
+export interface Ability {
+  id: string;
+  cooldown: number; // ms
+  snapshot?: boolean;
+}
+
+export const ABILITIES: Record<string, Ability> = {
+  AA: { id: 'AA', cooldown: 30000 },
+  SW: { id: 'SW', cooldown: 30000 },
+  YH: { id: 'YH', cooldown: 30000 },
+  FoF: { id: 'FoF', cooldown: 24000, snapshot: true },
+  RSK: { id: 'RSK', cooldown: 10000, snapshot: true },
+  WU: { id: 'WU', cooldown: 25000, snapshot: true },
+  BL: { id: 'BL', cooldown: 0 },
+};
+
+export function abilityById(id: string): Ability {
+  const a = ABILITIES[id];
+  if (!a) throw new Error(`ability ${id} not found`);
+  return a;
+}

--- a/src/dynamicCooldown.ts
+++ b/src/dynamicCooldown.ts
@@ -1,0 +1,69 @@
+import { abilityById } from './constants/abilities';
+import { selectTotalHasteAt as calcTotalHasteAt, HasteBuff } from './lib/haste';
+
+export interface Buff extends HasteBuff {
+  key: string;
+}
+
+export interface Cooldown {
+  abilityId: string;
+  remainingMs: number;
+}
+
+export interface RootState {
+  now: number;
+  hasteRating: number;
+  buffs: Buff[];
+  cooldowns: Cooldown[];
+}
+
+export function createState(hasteRating = 0): RootState {
+  return { now: 0, hasteRating, buffs: [], cooldowns: [] };
+}
+
+export function buffActive(state: RootState, key: string, t: number) {
+  return state.buffs.some(b => b.key === key && b.start <= t && t < b.end);
+}
+
+export const dragonsOverlap = (state: RootState, t: number) =>
+  buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
+
+export function selectTotalHasteAt(state: RootState, t: number) {
+  return calcTotalHasteAt(state.buffs, state.hasteRating, t);
+}
+
+export function getEffectiveTickRate(state: RootState, abilityId: string, now: number) {
+  const ability = abilityById(abilityId);
+  if (ability.snapshot) return 1;
+  const base = selectTotalHasteAt(state, now);
+  const sync = dragonsOverlap(state, now) ? 1.8 : 0;
+  return Math.max(base, sync);
+}
+
+export function advanceTime(state: RootState, dt: number) {
+  const now = state.now + dt;
+  // dynamic cooldowns accelerate if haste increases mid-way
+  for (const cd of state.cooldowns) {
+    const rate = getEffectiveTickRate(state, cd.abilityId, now);
+    cd.remainingMs = Math.max(0, cd.remainingMs - dt * rate);
+  }
+  state.now = now;
+}
+
+export function cast(state: RootState, abilityId: string) {
+  const ability = abilityById(abilityId);
+  if (abilityId === 'AA') {
+    state.buffs.push({ key: 'AA', start: state.now, end: state.now + 6000 });
+  } else if (abilityId === 'SW') {
+    state.buffs.push({ key: 'SW', start: state.now, end: state.now + 8000 });
+  } else if (abilityId === 'BL') {
+    state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
+  }
+  const haste = selectTotalHasteAt(state, state.now);
+  const duration = ability.snapshot ? ability.cooldown / haste : ability.cooldown;
+  state.cooldowns.push({ abilityId, remainingMs: duration });
+}
+
+export function getCooldown(state: RootState, abilityId: string) {
+  return state.cooldowns.find(c => c.abilityId === abilityId);
+}

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { createState, cast, advanceTime, getCooldown, selectTotalHasteAt } from '../src/dynamicCooldown';
+
+describe('dragon sync dynamic cooldown', () => {
+  it('AA+SW overlap sweeps 1.8s per s', () => {
+    const st = createState();
+    cast(st, 'AA');
+    cast(st, 'SW');
+    cast(st, 'YH');
+    advanceTime(st, 5000);
+    expect(getCooldown(st, 'YH')!.remainingMs).toBeCloseTo(30000 - 5000 * 1.8, 0);
+  });
+
+  it('haste added mid-cd accelerates', () => {
+    const st = createState();
+    cast(st, 'YH');
+    advanceTime(st, 5000); // 25s left
+    cast(st, 'BL');
+    advanceTime(st, 5000);
+    expect(getCooldown(st, 'YH')!.remainingMs).toBeCloseTo(25000 - 5000 * 1.3, 0);
+  });
+
+  it('snapshot skills ignore retro haste', () => {
+    const st = createState();
+    cast(st, 'FoF');
+    advanceTime(st, 2000);
+    const initialHaste = selectTotalHasteAt(st, 0);
+    cast(st, 'BL');
+    advanceTime(st, 2000);
+    expect(getCooldown(st, 'FoF')!.remainingMs).toBeCloseTo(24000 / initialHaste - 4000, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add ability constants with snapshot flags
- implement cooldown engine that accelerates with haste and Dragon Sync
- include tests for Dragon Sync overlap and haste changes

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68823dcfc310832fa2e60900589d6f06