### PR TITLE
Implement dynamic cooldown tick rate with dragon sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -1,0 +1,19 @@
+export interface Ability {
+  id: string;
+  cooldownMs: number;
+  snapshot?: boolean;
+}
+
+export const abilityMap: Record<string, Ability> = {
+  BL: { id: 'BL', cooldownMs: 0 },
+  AA: { id: 'AA', cooldownMs: 30_000 },
+  SW: { id: 'SW', cooldownMs: 30_000 },
+  YH: { id: 'YH', cooldownMs: 30_000 },
+  FoF: { id: 'FoF', cooldownMs: 24_000, snapshot: true },
+  RSK: { id: 'RSK', cooldownMs: 10_000, snapshot: true },
+  WU: { id: 'WU', cooldownMs: 25_000, snapshot: true },
+};
+
+export function abilityById(id: string): Ability {
+  return abilityMap[id];
+}

--- a/src/dynamicCooldown.ts
+++ b/src/dynamicCooldown.ts
@@ -1,0 +1,77 @@
+import { abilityById } from './constants/abilities';
+import { ratingToHaste } from './lib/haste';
+
+export interface Buff {
+  key: string;
+  start: number;
+  end: number;
+  multiplier?: number;
+}
+
+export interface CooldownRec {
+  abilityId: string;
+  remainingMs: number;
+}
+
+export interface RootState {
+  now: number;
+  rating: number;
+  buffs: Buff[];
+  cooldowns: CooldownRec[];
+}
+
+export function createState(rating = 0): RootState {
+  return { now: 0, rating, buffs: [], cooldowns: [] };
+}
+
+export function buffActive(state: RootState, key: string, t: number) {
+  return state.buffs.some(b => b.key === key && t >= b.start && t < b.end);
+}
+
+export function selectTotalHasteAt(state: RootState, t: number) {
+  const gear = 1 + ratingToHaste(state.rating);
+  const mult = state.buffs
+    .filter(b => t >= b.start && t < b.end)
+    .reduce((p, b) => p * (b.multiplier ?? 1), 1);
+  return gear * mult;
+}
+
+export function dragonsOverlap(state: RootState, t: number) {
+  return buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
+}
+
+export function getEffectiveTickRate(state: RootState, abilityId: string, now: number) {
+  const ability = abilityById(abilityId);
+  const base = ability.snapshot ? 1 : selectTotalHasteAt(state, now);
+  const sync = dragonsOverlap(state, now) ? 1.8 : 0;
+  return Math.max(base, sync);
+}
+
+export function cast(state: RootState, abilityId: string) {
+  const ability = abilityById(abilityId);
+  if (!ability) return;
+  const cd = ability.snapshot
+    ? ability.cooldownMs / selectTotalHasteAt(state, state.now)
+    : ability.cooldownMs;
+  state.cooldowns.push({ abilityId, remainingMs: cd });
+  if (abilityId === 'AA') {
+    state.buffs.push({ key: 'AA', start: state.now, end: state.now + 6_000 });
+  } else if (abilityId === 'SW') {
+    state.buffs.push({ key: 'SW', start: state.now, end: state.now + 8_000 });
+  } else if (abilityId === 'BL') {
+    state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40_000, multiplier: 1.3 });
+  }
+}
+
+export function advanceTime(state: RootState, dt: number) {
+  const now = state.now + dt;
+  for (const cd of state.cooldowns) {
+    const rate = getEffectiveTickRate(state, cd.abilityId, now);
+    cd.remainingMs = Math.max(0, cd.remainingMs - dt * rate);
+  }
+  state.buffs = state.buffs.filter(b => now < b.end);
+  state.now = now;
+}
+export function getCooldown(state: RootState, abilityId: string) {
+  return state.cooldowns.find(c => c.abilityId === abilityId);
+}

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { createState, cast, advanceTime, getCooldown, selectTotalHasteAt } from '../src/dynamicCooldown';
+
+describe('dragon sync sweep', () => {
+  it('AA+SW overlap sweeps 1.8s per s', () => {
+    const s = createState();
+    cast(s, 'AA');
+    cast(s, 'SW');
+    cast(s, 'YH');
+    advanceTime(s, 5_000);
+    expect(getCooldown(s, 'YH')!.remainingMs).toBeCloseTo(30_000 - 5_000 * 1.8, 0);
+  });
+
+  it('haste added mid-cd accelerates', () => {
+    const s = createState();
+    cast(s, 'YH');
+    advanceTime(s, 5_000);
+    cast(s, 'BL');
+    advanceTime(s, 5_000);
+    expect(getCooldown(s, 'YH')!.remainingMs).toBeCloseTo(25_000 - 5_000 * 1.3, 0);
+  });
+
+  it('snapshot skills ignore retro haste', () => {
+    const s = createState();
+    const initialHaste = selectTotalHasteAt(s, 0);
+    cast(s, 'FoF');
+    advanceTime(s, 2_000);
+    cast(s, 'BL');
+    advanceTime(s, 2_000);
+    expect(getCooldown(s, 'FoF')!.remainingMs).toBeCloseTo(24_000 / initialHaste - 4_000, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add ability definitions with snapshot flag
- implement dynamic cooldown engine with Dragon Sync sweep
- include haste-responsive tick rates and buff cleanup
- test new behavior

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68823dcfc310832fa2e60900589d6f06