### PR TITLE
Implement stateless dynamic cooldown integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,35 +1,68 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, HasteBuff } from '../lib/haste';
+import { elapsedCdMs } from '../utils/cooldownIntegrate';
+
+export interface GearChange {
+  start: number;
+  rating: number;
+}
 
 export interface Buff extends HasteBuff { key: string }
 
-export interface CooldownRec {
+export interface SnapshotCd {
   abilityId: string;
   remainingMs: number;
-  snapshot: boolean;
+}
+
+export interface DynamicCast {
+  abilityId: string;
+  castTime: number;
 }
 
 export interface RootState {
   now: number;
-  gearRating: number;
+  gear: GearChange[];
   buffs: Buff[];
-  active: CooldownRec[];
+  snapshotCds: SnapshotCd[];
+  dynamicCasts: DynamicCast[];
 }
 
 export function createState(gearRating = 0): RootState {
-  return { now: 0, gearRating, buffs: [], active: [] };
+  return {
+    now: 0,
+    gear: [{ start: 0, rating: gearRating }],
+    buffs: [],
+    snapshotCds: [],
+    dynamicCasts: [],
+  };
+}
+
+export function setGearRating(state: RootState, rating: number) {
+  state.gear.push({ start: state.now, rating });
 }
 
 export function buffActive(state: RootState, key: string, t: number) {
   return state.buffs.some(b => b.key === key && b.start <= t && t < b.end);
 }
 
+export function gearRatingAt(state: RootState, t: number) {
+  let rating = state.gear[0]?.rating ?? 0;
+  for (const g of state.gear) {
+    if (g.start <= t) rating = g.rating;
+    else break;
+  }
+  return rating;
+}
+
 export function dragonsOverlap(state: RootState, t: number) {
   return buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
 }
 
+export const hasDragonSweep = dragonsOverlap;
+
 export function selectTotalHasteAt(state: RootState, t: number) {
-  return hasteAt(state.buffs, state.gearRating, t);
+  const rating = gearRatingAt(state, t);
+  return hasteAt(state.buffs, rating, t);
 }
 
 export function getEffectiveTickRate(
@@ -46,11 +79,11 @@ export function getEffectiveTickRate(
 
 export function advanceTime(state: RootState, dt: number) {
   const now = state.now + dt;
-  for (const cd of state.active) {
-    const rate = getEffectiveTickRate(state, cd.abilityId, now);
-    cd.remainingMs = Math.max(0, cd.remainingMs - dt * rate);
+  for (const cd of state.snapshotCds) {
+    cd.remainingMs = Math.max(0, cd.remainingMs - dt);
   }
-  state.buffs = state.buffs.filter(b => b.end > now);
+  // prune finished snapshot cds
+  state.snapshotCds = state.snapshotCds.filter(c => c.remainingMs > 0);
   state.now = now;
 }
 
@@ -64,15 +97,32 @@ export function cast(state: RootState, abilityId: string) {
     state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
   }
   if (ability.cooldownMs > 0) {
-    const rem = ability.snapshot
-      ? ability.cooldownMs / selectTotalHasteAt(state, state.now)
-      : ability.cooldownMs;
-    const existing = state.active.find(c => c.abilityId === abilityId);
-    if (existing) existing.remainingMs = rem;
-    else state.active.push({ abilityId, remainingMs: rem, snapshot: !!ability.snapshot });
+    if (ability.snapshot) {
+      const rem = ability.cooldownMs / selectTotalHasteAt(state, state.now);
+      const ex = state.snapshotCds.find(c => c.abilityId === abilityId);
+      if (ex) ex.remainingMs = rem;
+      else state.snapshotCds.push({ abilityId, remainingMs: rem });
+    } else {
+      const ex = state.dynamicCasts.find(c => c.abilityId === abilityId);
+      if (ex) ex.castTime = state.now;
+      else state.dynamicCasts.push({ abilityId, castTime: state.now });
+    }
   }
 }
 
-export function getCooldown(state: RootState, abilityId: string) {
-  return state.active.find(c => c.abilityId === abilityId);
+export function selectRemainingCd(state: RootState, abilityId: string): number {
+  const ability = abilityById(abilityId);
+  if (ability.snapshot) {
+    return (
+      state.snapshotCds.find(c => c.abilityId === abilityId)?.remainingMs ?? 0
+    );
+  }
+  const cast = state.dynamicCasts.find(c => c.abilityId === abilityId);
+  if (!cast) return 0;
+  return Math.max(
+    0,
+    ability.cooldownMs - elapsedCdMs(state, abilityId, cast.castTime, state.now),
+  );
 }
+
+export const getCooldown = selectRemainingCd;

--- a/src/utils/cooldownIntegrate.ts
+++ b/src/utils/cooldownIntegrate.ts
@@ -1,0 +1,21 @@
+import { RootState } from '../logic/dynamicEngine';
+import { abilityById } from '../constants/abilities';
+import { getEffectiveTickRate } from '../logic/dynamicEngine';
+
+export function elapsedCdMs(
+  state: RootState,
+  abilityId: string,
+  cast: number,
+  now: number,
+): number {
+  let t = cast;
+  let soFar = 0;
+  const dt = 100; // ms step
+  const baseCd = abilityById(abilityId).cooldownMs;
+  while (t < now && soFar < baseCd) {
+    const rate = getEffectiveTickRate(state, abilityId, t + dt / 2);
+    soFar += dt * rate;
+    t += dt;
+  }
+  return Math.min(soFar, baseCd);
+}

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -12,7 +12,7 @@ it('AA+SW overlap sweeps 1.8s per s', () => {
   cast(state, 'SW');
   cast(state, 'YH');
   advanceTime(state, 5000);
-  expect(getCooldown(state, 'YH')!.remainingMs).toBeCloseTo(30000 - 5000 * 1.8, 0);
+  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 1.8, 0);
 });
 
 it('haste added mid-cd accelerates', () => {
@@ -20,7 +20,7 @@ it('haste added mid-cd accelerates', () => {
   advanceTime(state, 5000);
   cast(state, 'BL');
   advanceTime(state, 5000);
-  expect(getCooldown(state, 'YH')!.remainingMs).toBeCloseTo(25000 - 5000 * 1.3, 0);
+  expect(getCooldown(state, 'YH')).toBeCloseTo(25000 - 5000 * 1.3, 0);
 });
 
 it('snapshot skills ignore retro haste', () => {
@@ -29,5 +29,5 @@ it('snapshot skills ignore retro haste', () => {
   advanceTime(state, 2000);
   cast(state, 'BL');
   advanceTime(state, 2000);
-  expect(getCooldown(state, 'FoF')!.remainingMs).toBeCloseTo(24000 / initialHaste - 4000, 0);
+  expect(getCooldown(state, 'FoF')).toBeCloseTo(24000 / initialHaste - 4000, 0);
 });

--- a/tests/dynamic_cd_recalc.spec.ts
+++ b/tests/dynamic_cd_recalc.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createState, cast, advanceTime, setGearRating, getCooldown } from '../src/logic/dynamicEngine';
+
+let s: ReturnType<typeof createState>;
+const RATING_50 = 35829; // ~= 50% haste
+
+beforeEach(() => {
+  s = createState();
+});
+
+describe('dynamic cooldown recomputation', () => {
+  it('gear haste slider instantly updates remaining CD', () => {
+    cast(s, 'YH');
+    advanceTime(s, 10000);
+    expect(getCooldown(s, 'YH')).toBeCloseTo(20000, 0);
+    setGearRating(s, RATING_50); // from now on haste 1.5x
+    expect(getCooldown(s, 'YH')).toBeCloseTo(20000, 0);
+    advanceTime(s, 5000);
+    expect(getCooldown(s, 'YH')).toBeCloseTo(12500, 0);
+  });
+
+  it('retro drag of Bloodlust alters past integration', () => {
+    cast(s, 'YH');
+    advanceTime(s, 5000);
+    cast(s, 'BL'); // BL starts at t=5s
+    advanceTime(s, 5000); // now t=10s
+    const original = getCooldown(s, 'YH');
+    // shift BL 5s earlier so it covers t=0-40s
+    s.buffs[0].start -= 5000;
+    s.buffs[0].end -= 5000;
+    expect(getCooldown(s, 'YH')).toBeLessThanOrEqual(original - 5000 * 0.3);
+  });
+
+  it('AA+SW overlap sweep integrates 1.8× section', () => {
+    cast(s, 'AA');
+    cast(s, 'SW');
+    cast(s, 'YH');
+    advanceTime(s, 25000);
+    const elapsed = 6000 * 1.8 + 19000 * 1; // AA 6s, rest normal
+    expect(getCooldown(s, 'YH')).toBeCloseTo(30000 - elapsed, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- compute cooldowns by integrating tick rate instead of mutating state
- preserve past buff history for retroactive edits
- provide `elapsedCdMs` helper and expose `selectRemainingCd`
- add regression tests covering haste slider, retro Bloodlust drag and dragon sweep

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_688242ce1f78832f8aae951650c300ed