### PR TITLE
feat(ui): convert ability palette to four horizontal rows grouped by timeline category

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/ui_palette.spec.tsx",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { computeBlessingSegments } from './util/blessingSegments';
 import { SkillCast } from './types';
 import TPIcon from './Pics/TP.jpg';
 import { AbilityIcon } from './components/AbilityIcon';
+import { AbilityPalette } from './components/AbilityPalette';
 import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 
@@ -480,17 +481,7 @@ export default function App() {
         <button onClick={() => setShowCD(!showCD)} className="px-2 py-1 border rounded">
           {showCD ? t('隐藏CD') : t('显示CD')}
         </button>
-        {Object.keys(abilities).map(k => (
-          <div key={k} className="flex flex-col items-center w-4 h-4">
-            <button onClick={() => click(k as WWKey)}
-              className="w-4 h-4 bg-blue-500 text-white rounded relative overflow-hidden">
-              {k === 'TP'
-                ? <img src={TPIcon} alt={abilities[k as WWKey].name} className="w-full h-full" />
-                : <AbilityIcon abilityKey={k} />}
-            </button>
-            <span className="text-xs">{cdLabel(k as WWKey)}</span>
-          </div>
-        ))}
+        <AbilityPalette abilities={abilities} onUse={click} />
       </div>
 
       {selected !== null && (() => {

--- a/src/components/AbilityPalette.tsx
+++ b/src/components/AbilityPalette.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { AbilityIcon } from './AbilityIcon';
+import { TIMELINE_ROW_ORDER, TimelineRow } from '../constants/timelineRows';
+import { wwData, WWKey } from '../jobs/windwalker';
+import TPIcon from '../Pics/TP.jpg';
+
+interface Props {
+  abilities: ReturnType<typeof wwData>;
+  onUse: (key: WWKey) => void;
+}
+
+const ROW_MAP: Record<WWKey, TimelineRow> = {
+  Xuen: 'majorCd',
+  SEF: 'majorCd',
+  CC: 'majorCd',
+  AA: 'minorCd',
+  SW: 'minorCd',
+  FoF: 'majorFiller',
+  RSK: 'majorFiller',
+  WU: 'majorFiller',
+  TP: 'minorFiller',
+  BOK: 'minorFiller',
+  BL: 'majorCd', // put BL with major cds
+};
+
+export const AbilityPalette = ({ abilities, onUse }: Props) => (
+  <div className="ability-grid">
+    {TIMELINE_ROW_ORDER.map(row => (
+      <div key={row} className="ability-row" role="list" data-row={row}>
+        {Object.keys(abilities)
+          .filter(k => ROW_MAP[k as WWKey] === row)
+          .map(k => (
+            <button
+              key={k}
+              onClick={() => onUse(k as WWKey)}
+              draggable
+              onDragStart={e => {
+                e.dataTransfer.setData('text/plain', k);
+              }}
+              className="w-8 h-8 bg-blue-500 text-white rounded relative overflow-hidden"
+            >
+              {k === 'TP' ? (
+                <img src={TPIcon} alt={abilities[k as WWKey].name} className="w-full h-full" />
+              ) : (
+                <AbilityIcon abilityKey={k} />
+              )}
+            </button>
+          ))}
+      </div>
+    ))}
+  </div>
+);

--- a/src/constants/timelineRows.ts
+++ b/src/constants/timelineRows.ts
@@ -1,0 +1,7 @@
+export const TIMELINE_ROW_ORDER = [
+  'majorCd',
+  'minorCd',
+  'majorFiller',
+  'minorFiller',
+] as const;
+export type TimelineRow = typeof TIMELINE_ROW_ORDER[number];

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,21 @@ body.light {
   visibility: hidden;
 }
 
+
+.ability-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+}
+
+.ability-row {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.ability-row::-webkit-scrollbar {
+  height: 6px;
+}

--- a/tests/ui_palette.spec.tsx
+++ b/tests/ui_palette.spec.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { AbilityPalette } from '../src/components/AbilityPalette';
+import { wwData } from '../src/jobs/windwalker';
+import { TIMELINE_ROW_ORDER } from '../src/constants/timelineRows';
+
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+describe('AbilityPalette', () => {
+  it('renders four horizontal rows', async () => {
+    const abilities = wwData(0);
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<AbilityPalette abilities={abilities} onUse={() => {}} />);
+    });
+    const rows = div.querySelectorAll('.ability-row');
+    expect(rows.length).toBe(TIMELINE_ROW_ORDER.length);
+    rows.forEach(row => expect(row.classList.contains('ability-row')).toBe(true));
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- add timeline row constants
- render ability palette grouped into rows
- style palette rows with horizontal scrolling
- add ui test for new palette layout

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_688280a94910832f8621d7d45e61910d