### PR TITLE
feat: FoF channel scaling & sweep fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/ui_palette.spec.tsx",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/fof_channel.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -2,15 +2,17 @@ export interface Ability {
   id: string;
   cooldownMs: number;
   snapshot?: boolean;
+  baseChannelMs?: number;
 }
 
 export const ABILITIES: Record<string, Ability> = {
   AA: { id: 'AA', cooldownMs: 30000 },
   SW: { id: 'SW', cooldownMs: 30000 },
   YH: { id: 'YH', cooldownMs: 30000 },
-  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true },
+  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true, baseChannelMs: 4000 },
   RSK: { id: 'RSK', cooldownMs: 10000, snapshot: true },
   WU: { id: 'WU', cooldownMs: 25000, snapshot: true },
+  CC: { id: 'CC', cooldownMs: 90000 },
   BL: { id: 'BL', cooldownMs: 0 },
 };
 

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,6 +1,7 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
+import { hasCdSweep } from '../selectors/dragonSweep';
 
 export interface GearChange {
   start: number;
@@ -58,8 +59,6 @@ export function dragonsOverlap(state: RootState, t: number) {
   return buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
 }
 
-export const hasDragonSweep = dragonsOverlap;
-
 export function selectTotalHasteAt(state: RootState, t: number) {
   const rating = gearRatingAt(state, t);
   return hasteAt(state.buffs, rating, t);
@@ -72,9 +71,9 @@ export function getEffectiveTickRate(
 ): number {
   const ability = abilityById(abilityId);
   if (ability.snapshot) return 1;
-  const base = selectTotalHasteAt(state, now);
-  const sync = dragonsOverlap(state, now) ? 1.8 : 0;
-  return Math.max(base, sync);
+  const baseRate = selectTotalHasteAt(state, now);
+  const sweepRate = hasCdSweep(state, now) ? 1.8 : 0;
+  return Math.max(baseRate, sweepRate);
 }
 
 export function advanceTime(state: RootState, dt: number) {
@@ -93,6 +92,8 @@ export function cast(state: RootState, abilityId: string) {
     state.buffs.push({ key: 'AA', start: state.now, end: state.now + 6000 });
   } else if (abilityId === 'SW') {
     state.buffs.push({ key: 'SW', start: state.now, end: state.now + 8000 });
+  } else if (abilityId === 'CC') {
+    state.buffs.push({ key: 'CC', start: state.now, end: state.now + 6000 });
   } else if (abilityId === 'BL') {
     state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
   }

--- a/src/selectors/dragonSweep.ts
+++ b/src/selectors/dragonSweep.ts
@@ -1,0 +1,5 @@
+import { buffActive } from '../logic/dynamicEngine';
+import type { RootState } from '../logic/dynamicEngine';
+
+export const hasCdSweep = (state: RootState, t: number) =>
+  buffActive(state, 'AA', t) && buffActive(state, 'SW', t);

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -1,0 +1,11 @@
+import { RootState, buffActive, selectTotalHasteAt } from '../logic/dynamicEngine';
+
+export { selectTotalHasteAt } from '../logic/dynamicEngine';
+
+export function dragonsStateAt(state: RootState, t: number) {
+  return {
+    sw: buffActive(state, 'SW', t),
+    aa: buffActive(state, 'AA', t),
+    cc: buffActive(state, 'CC', t),
+  };
+}

--- a/src/utils/channelTime.ts
+++ b/src/utils/channelTime.ts
@@ -1,0 +1,9 @@
+import { RootState } from '../logic/dynamicEngine';
+import { selectTotalHasteAt, dragonsStateAt } from '../selectors';
+
+export function calcFoFChannel(state: RootState, cast: number): number {
+  const haste = selectTotalHasteAt(state, cast);
+  const { sw, aa, cc } = dragonsStateAt(state, cast);
+  const dragonFactor = sw && (aa || cc) ? 0.25 : (sw || aa || cc) ? 0.5 : 1;
+  return 4000 / haste * dragonFactor;
+}

--- a/tests/dragon_sweep.spec.ts
+++ b/tests/dragon_sweep.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { createState, cast, advanceTime, getCooldown } from '../src/logic/dynamicEngine';
+
+it('CD sweep only when AA+SW, not CC+SW', () => {
+  let s = createState();
+  cast(s, 'AA');
+  cast(s, 'SW');
+  cast(s, 'YH');
+  advanceTime(s, 5000);
+  expect(getCooldown(s, 'YH')).toBeLessThan(30000 - 5000 * 1.8 + 1);
+
+  s = createState();
+  cast(s, 'CC');
+  cast(s, 'SW');
+  cast(s, 'YH');
+  advanceTime(s, 5000);
+  expect(getCooldown(s, 'YH')).toBeCloseTo(25000, 0);
+});
+

--- a/tests/fof_channel.spec.ts
+++ b/tests/fof_channel.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createState, cast, setGearRating } from '../src/logic/dynamicEngine';
+import { calcFoFChannel } from '../src/utils/channelTime';
+
+let state: ReturnType<typeof createState>;
+const RATING_20 = 13200; // ~20% haste
+
+beforeEach(() => {
+  state = createState();
+});
+
+describe('FoF channel time', () => {
+  it('FoF channel scales with haste and dragon factor', () => {
+    setGearRating(state, RATING_20); // 1.2x haste
+    cast(state, 'SW'); // dragon factor 0.5
+    const haste = 1.2;
+    const expected = 4000 / haste * 0.5;
+    const duration = calcFoFChannel(state, state.now);
+    expect(duration).toBeCloseTo(expected, 0);
+  });
+
+  it('FoF channel uses 0.25 when SW+AA', () => {
+    cast(state, 'SW');
+    cast(state, 'AA');
+    const expected = 4000 / 1 * 0.25;
+    const duration = calcFoFChannel(state, state.now);
+    expect(duration).toBeCloseTo(expected, 0);
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
     "src/combat/**/*.ts",
     "src/constants/**/*.ts",
     "src/logic/**/*.ts",
+    "src/selectors/**/*.ts",
+    "src/utils/**/*.ts",
     "src/__tests__/**/*.ts",
     "tests/**/*.ts"
   ]


### PR DESCRIPTION
## Summary
- channel duration for FoF now scales with haste and dragon buffs
- cooldown sweep requires AA and SW overlap
- add FoF channel and sweep unit tests

## Testing
- `pnpm run test`
- `pnpm run dev` *(manual check, server started)*

------
https://chatgpt.com/codex/tasks/task_e_688282ec2970832fabe4af0b2029bdfb