### PR TITLE
Dynamic channel integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/fof_channel.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/fof_channel.spec.ts tests/dragon_sweep.spec.ts tests/channel_dynamic.spec.ts tests/ui_palette.spec.tsx",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -512,6 +512,9 @@ export default function App() {
               />
             </label>
             <div>{t('转好时间')}: {formatTime(endAt)}</div>
+            {it.end && it.end > time && (
+              <div>• Channel: {(it.end - time).toFixed(2)}s remaining</div>
+            )}
             {(() => {
               const prev = (casts[it.ability ?? ''] || [])
                 .filter(c => c.id !== selected && c.start < it.start)

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -3,16 +3,17 @@ export interface Ability {
   cooldownMs: number;
   snapshot?: boolean;
   baseChannelMs?: number;
+  channelDynamic?: boolean;
 }
 
 export const ABILITIES: Record<string, Ability> = {
   AA: { id: 'AA', cooldownMs: 30000 },
-  SW: { id: 'SW', cooldownMs: 30000 },
+  SW: { id: 'SW', cooldownMs: 30000, baseChannelMs: 2000, channelDynamic: true },
   YH: { id: 'YH', cooldownMs: 30000 },
-  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true, baseChannelMs: 4000 },
+  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true, baseChannelMs: 4000, channelDynamic: true },
   RSK: { id: 'RSK', cooldownMs: 10000, snapshot: true },
   WU: { id: 'WU', cooldownMs: 25000, snapshot: true },
-  CC: { id: 'CC', cooldownMs: 90000 },
+  CC: { id: 'CC', cooldownMs: 90000, baseChannelMs: 1500, channelDynamic: true },
   BL: { id: 'BL', cooldownMs: 0 },
 };
 

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,6 +1,7 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
+import { elapsedChannelMs, channelDurationMs } from '../utils/channelIntegrate';
 import { hasCdSweep } from '../selectors/dragonSweep';
 
 export interface GearChange {
@@ -20,12 +21,18 @@ export interface DynamicCast {
   castTime: number;
 }
 
+export interface ChannelCast {
+  abilityId: string;
+  castTime: number;
+}
+
 export interface RootState {
   now: number;
   gear: GearChange[];
   buffs: Buff[];
   snapshotCds: SnapshotCd[];
   dynamicCasts: DynamicCast[];
+  channels: Record<string, ChannelCast | undefined>;
 }
 
 export function createState(gearRating = 0): RootState {
@@ -35,6 +42,7 @@ export function createState(gearRating = 0): RootState {
     buffs: [],
     snapshotCds: [],
     dynamicCasts: [],
+    channels: {},
   };
 }
 
@@ -97,6 +105,9 @@ export function cast(state: RootState, abilityId: string) {
   } else if (abilityId === 'BL') {
     state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
   }
+  if (ability.channelDynamic) {
+    state.channels[abilityId] = { abilityId, castTime: state.now };
+  }
   if (ability.cooldownMs > 0) {
     if (ability.snapshot) {
       const rem = ability.cooldownMs / selectTotalHasteAt(state, state.now);
@@ -127,3 +138,10 @@ export function selectRemainingCd(state: RootState, abilityId: string): number {
 }
 
 export const getCooldown = selectRemainingCd;
+
+export function selectRemainingChannelMs(state: RootState, abilityId: string): number {
+  const cast = state.channels[abilityId]?.castTime;
+  if (cast == null) return 0;
+  const duration = channelDurationMs(state, abilityId, cast);
+  return Math.max(0, duration - (state.now - cast));
+}

--- a/src/selectors/dragons.ts
+++ b/src/selectors/dragons.ts
@@ -1,0 +1,11 @@
+import { buffActive } from '../logic/dynamicEngine';
+import type { RootState } from '../logic/dynamicEngine';
+
+export function dragonFactorAt(state: RootState, t: number): number {
+  const sw = buffActive(state, 'SW', t);
+  const aa = buffActive(state, 'AA', t);
+  const cc = buffActive(state, 'CC', t);
+  if (sw && (aa || cc)) return 0.25;
+  if (sw || aa || cc) return 0.5;
+  return 1;
+}

--- a/src/selectors/index.ts
+++ b/src/selectors/index.ts
@@ -1,6 +1,7 @@
 import { RootState, buffActive, selectTotalHasteAt } from '../logic/dynamicEngine';
 
-export { selectTotalHasteAt } from '../logic/dynamicEngine';
+export { selectTotalHasteAt, selectRemainingChannelMs } from '../logic/dynamicEngine';
+export { dragonFactorAt } from './dragons';
 
 export function dragonsStateAt(state: RootState, t: number) {
   return {

--- a/src/utils/channelIntegrate.ts
+++ b/src/utils/channelIntegrate.ts
@@ -1,0 +1,61 @@
+import { abilityById } from '../constants/abilities';
+import type { RootState } from '../logic/dynamicEngine';
+import { selectTotalHasteAt } from '../selectors';
+import { dragonFactorAt } from '../selectors/dragons';
+
+export function elapsedChannelMs(
+  state: RootState,
+  abilityId: string,
+  cast: number,
+  now: number,
+): number {
+  const ability = abilityById(abilityId);
+  const dt = 100;
+  let t = cast;
+  let acc = 0;
+  while (t < now && acc < (ability.baseChannelMs ?? 0)) {
+    const haste = selectTotalHasteAt(state, t);
+    const rate =
+      abilityId === 'FoF'
+        ? haste / dragonFactorAt(state, t)
+        : haste;
+    const delta = dt * rate;
+    if (acc + delta > (ability.baseChannelMs ?? 0)) {
+      const remain = (ability.baseChannelMs ?? 0) - acc;
+      acc = ability.baseChannelMs ?? 0;
+      t += remain / rate;
+      break;
+    }
+    acc += delta;
+    t += dt;
+  }
+  return Math.min(acc, ability.baseChannelMs ?? 0);
+}
+
+export function channelDurationMs(
+  state: RootState,
+  abilityId: string,
+  cast: number,
+): number {
+  const ability = abilityById(abilityId);
+  const dt = 100;
+  let t = cast;
+  let acc = 0;
+  while (acc < (ability.baseChannelMs ?? 0)) {
+    const haste = selectTotalHasteAt(state, t);
+    const rate =
+      abilityId === 'FoF'
+        ? haste / dragonFactorAt(state, t)
+        : haste;
+    const delta = dt * rate;
+    if (acc + delta >= (ability.baseChannelMs ?? 0)) {
+      const remain = (ability.baseChannelMs ?? 0) - acc;
+      t += remain / rate;
+      acc = ability.baseChannelMs ?? 0;
+      break;
+    }
+    acc += delta;
+    t += dt;
+  }
+  return t - cast;
+}

--- a/tests/channel_dynamic.spec.ts
+++ b/tests/channel_dynamic.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createState, cast, advanceTime, selectRemainingChannelMs } from '../src/logic/dynamicEngine';
+
+let s: ReturnType<typeof createState>;
+
+beforeEach(() => {
+  s = createState();
+});
+
+describe('dynamic channel recomputation', () => {
+  it('FoF channel updates when haste added mid-cast', () => {
+    cast(s, 'FoF');
+    advanceTime(s, 1000);
+    const before = selectRemainingChannelMs(s, 'FoF');
+    cast(s, 'BL');
+    expect(selectRemainingChannelMs(s, 'FoF')).toBeLessThan(before);
+  });
+
+  it('FoF dragonFactor 0.25 live', () => {
+    cast(s, 'FoF');
+    advanceTime(s, 200);
+    cast(s, 'SW');
+    cast(s, 'AA');
+    expect(selectRemainingChannelMs(s, 'FoF')).toBeLessThan(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- enable dynamic channel metadata for FoF, CC and SW
- compute channel progress via `channelDurationMs`
- expose new selector `selectRemainingChannelMs`
- add dragon helper selector
- show channel remaining time in ability info panel
- test dynamic channel behavior

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_688287f57bf0832f8772a6bf13370df5