### PR TITLE
Implement dynamic channel calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/fof_channel.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/fof_channel.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx tests/channel_dynamic.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -3,16 +3,17 @@ export interface Ability {
   cooldownMs: number;
   snapshot?: boolean;
   baseChannelMs?: number;
+  channelDynamic?: boolean;
 }
 
 export const ABILITIES: Record<string, Ability> = {
   AA: { id: 'AA', cooldownMs: 30000 },
-  SW: { id: 'SW', cooldownMs: 30000 },
+  SW: { id: 'SW', cooldownMs: 30000, baseChannelMs: 2000, channelDynamic: true },
   YH: { id: 'YH', cooldownMs: 30000 },
-  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true, baseChannelMs: 4000 },
+  FoF: { id: 'FoF', cooldownMs: 24000, snapshot: true, baseChannelMs: 4000, channelDynamic: true },
   RSK: { id: 'RSK', cooldownMs: 10000, snapshot: true },
   WU: { id: 'WU', cooldownMs: 25000, snapshot: true },
-  CC: { id: 'CC', cooldownMs: 90000 },
+  CC: { id: 'CC', cooldownMs: 90000, baseChannelMs: 1500, channelDynamic: true },
   BL: { id: 'BL', cooldownMs: 0 },
 };
 

--- a/src/selectors/dragons.ts
+++ b/src/selectors/dragons.ts
@@ -1,0 +1,11 @@
+import type { RootState } from '../logic/dynamicEngine';
+import { buffActive } from '../logic/dynamicEngine';
+
+export function dragonFactorAt(state: RootState, t: number): number {
+  const sw = buffActive(state, 'SW', t);
+  const aa = buffActive(state, 'AA', t);
+  const cc = buffActive(state, 'CC', t);
+  if (sw && (aa || cc)) return 0.25;
+  if (sw || aa || cc) return 0.5;
+  return 1;
+}

--- a/src/utils/channelIntegrate.ts
+++ b/src/utils/channelIntegrate.ts
@@ -1,0 +1,25 @@
+import { abilityById } from '../constants/abilities';
+import type { RootState } from '../logic/dynamicEngine';
+import { selectTotalHasteAt } from '../logic/dynamicEngine';
+import { dragonFactorAt } from '../selectors/dragons';
+
+export function elapsedChannelMs(
+  state: RootState,
+  abilityId: string,
+  cast: number,
+  now: number,
+): number {
+  const ability = abilityById(abilityId);
+  const dt = 100;
+  let t = cast;
+  let acc = 0;
+  while (t < now && acc < (ability.baseChannelMs ?? 0)) {
+    const haste = selectTotalHasteAt(state, t);
+    const rate = abilityId === 'FoF'
+      ? haste / dragonFactorAt(state, t)
+      : haste;
+    acc += dt * rate;
+    t += dt;
+  }
+  return Math.min(acc, ability.baseChannelMs ?? 0);
+}

--- a/tests/channel_dynamic.spec.ts
+++ b/tests/channel_dynamic.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createState, cast, advanceTime, setGearRating, getChannel } from '../src/logic/dynamicEngine';
+
+let s: ReturnType<typeof createState>;
+
+beforeEach(() => {
+  s = createState();
+});
+
+describe('dynamic channel recomputation', () => {
+  it('FoF channel updates when haste added mid-cast', () => {
+    setGearRating(s, 0);
+    cast(s, 'FoF');
+    advanceTime(s, 1000);
+    const before = getChannel(s, 'FoF');
+    cast(s, 'BL');
+    expect(getChannel(s, 'FoF')).toBeLessThan(before);
+  });
+
+  it('FoF dragonFactor 0.25 live', () => {
+    cast(s, 'FoF');
+    advanceTime(s, 200);
+    cast(s, 'SW');
+    cast(s, 'AA');
+    expect(getChannel(s, 'FoF')).toBeLessThan(800);
+  });
+});


### PR DESCRIPTION
## Summary
- allow dynamic haste channels for FoF, SW and CC
- compute dragonFactor from active dragons
- add elapsed channel integrator and remaining selector
- track channel casts and drop when finished
- test live channel updates

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_688287f57bf0832f8772a6bf13370df5