### PR TITLE
Improve channel timing to update with buffs

### DIFF
--- a/src/selectors/channel.ts
+++ b/src/selectors/channel.ts
@@ -1,6 +1,5 @@
-import { abilityById } from '../constants/abilities';
 import type { RootState } from '../logic/dynamicEngine';
-import { remainingChannelMs } from '../utils/channelIntegrate';
+import { remainingChannelTime } from '../utils/integrate';
 
 export const selectRemainingChannelMs = (
   state: RootState,
@@ -8,5 +7,5 @@ export const selectRemainingChannelMs = (
 ): number => {
   const cast = state.channels[id as keyof typeof state.channels]?.castTime;
   if (cast == null) return 0;
-  return remainingChannelMs(state, id, cast, state.now);
+  return remainingChannelTime(state, id as 'FoF' | 'CC' | 'SW', cast, state.now);
 };

--- a/src/utils/integrate.ts
+++ b/src/utils/integrate.ts
@@ -1,42 +1,42 @@
 import type { RootState } from '../logic/dynamicEngine';
 import { abilityById } from '../constants/abilities';
-import { selectTotalHasteAt } from '../selectors/haste';
+import { selectTotalHasteAt } from '../logic/dynamicEngine';
 import { dragonFactorAt } from '../selectors/dragons';
 
-export function elapsedChannelMs(
+export function integrateChannel(
   state: RootState,
-  abilityId: string,
+  abilityId: 'FoF' | 'CC' | 'SW',
   cast: number,
   now: number,
 ): number {
   const ability = abilityById(abilityId);
-  const dt = 100;
+  const dt = 50;
   let t = cast;
   let acc = 0;
-  while (t < now && acc < ability.baseChannelMs) {
+  while (t < now && acc < (ability.baseChannelMs ?? 0)) {
     const haste = selectTotalHasteAt(state, t);
-    const rate =
-      ability.id === 'FoF' ? haste / dragonFactorAt(state, t) : haste;
+    const dragon = abilityId === 'FoF' ? dragonFactorAt(state, t) : 1;
+    const rate = haste / dragon;
     acc += dt * rate;
     t += dt;
   }
-  return Math.min(acc, ability.baseChannelMs);
+  return acc;
 }
 
-export function remainingChannelMs(
+export function remainingChannelTime(
   state: RootState,
-  abilityId: string,
+  abilityId: 'FoF' | 'CC' | 'SW',
   cast: number,
   now: number,
 ): number {
   const ability = abilityById(abilityId);
-  const dt = 100;
+  const dt = 50;
   let t = cast;
   let acc = 0;
-  while (acc < ability.baseChannelMs) {
+  while (acc < (ability.baseChannelMs ?? 0)) {
     const haste = selectTotalHasteAt(state, t);
-    const rate =
-      ability.id === 'FoF' ? haste / dragonFactorAt(state, t) : haste;
+    const dragon = abilityId === 'FoF' ? dragonFactorAt(state, t) : 1;
+    const rate = haste / dragon;
     acc += dt * rate;
     t += dt;
     if (t - cast > 600000) break;

--- a/tests/channel_dynamic.spec.ts
+++ b/tests/channel_dynamic.spec.ts
@@ -29,3 +29,21 @@ it('FoF dragonFactor 0.25 live', () => {
   cast(s, 'AA');
   expect(selectRemainingChannelMs(s, 'FoF')).toBeLessThan(1100);
 });
+
+it('FoF channel updates when buffs dragged in', () => {
+  setGearRating(s, 0);
+  cast(s, 'FoF');
+  advanceTime(s, 500);
+  const before = selectRemainingChannelMs(s, 'FoF');
+  cast(s, 'SW');
+  cast(s, 'AA');
+  expect(selectRemainingChannelMs(s, 'FoF')).toBeLessThan(before * 0.7);
+});
+
+it('CC channel reacts to Bloodlust added after cast', () => {
+  cast(s, 'CC');
+  advanceTime(s, 700);
+  const before = selectRemainingChannelMs(s, 'CC');
+  cast(s, 'BL');
+  expect(selectRemainingChannelMs(s, 'CC')).toBeLessThan(before);
+});


### PR DESCRIPTION
## Summary
- replace channel end-time snapshot with stateless integration functions
- compute remaining channel time via new selectors
- update tests for dynamic channel behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68829c8eca98832fbe9c566f99968108