### PR TITLE
Fix channel remaining calculation

### DIFF
--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -27,10 +27,7 @@ export interface RootState {
   snapshotCds: SnapshotCd[];
   dynamicCasts: DynamicCast[];
   channels: {
-    FoF?: { castTime: number };
-    CC?: { castTime: number };
-    SW?: { castTime: number };
-    [key: string]: { castTime: number } | undefined;
+    active: Record<string, number>;
   };
 }
 
@@ -41,7 +38,7 @@ export function createState(gearRating = 0): RootState {
     buffs: [],
     snapshotCds: [],
     dynamicCasts: [],
-    channels: {},
+    channels: { active: {} },
   };
 }
 
@@ -105,7 +102,7 @@ export function cast(state: RootState, abilityId: string) {
     state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
   }
   if (ability.channelDynamic) {
-    state.channels[abilityId] = { castTime: state.now };
+    state.channels.active[abilityId] = state.now;
   }
   if (ability.cooldownMs > 0) {
     if (ability.snapshot) {
@@ -138,4 +135,4 @@ export function selectRemainingCd(state: RootState, abilityId: string): number {
 
 export const getCooldown = selectRemainingCd;
 
-export { selectRemFoF, selectRemCC, selectRemSW, makeRemainingChannelSelector } from '../selectors/channel';
+export { selectRemFoF, selectRemCC, selectRemSW, selectRemainingChannel } from '../selectors/channel';

--- a/src/selectors/buff.ts
+++ b/src/selectors/buff.ts
@@ -1,0 +1,1 @@
+export { buffActive } from '../logic/dynamicEngine';

--- a/src/selectors/channel.ts
+++ b/src/selectors/channel.ts
@@ -1,34 +1,31 @@
-import { selectTotalHasteAt, buffActive } from '../logic/dynamicEngine';
+import { selectTotalHasteAt } from './haste';
+import { buffActive } from './buff';
 import { abilityById } from '../constants/abilities';
 import type { RootState } from '../logic/dynamicEngine';
 
-const dragonFactorAt = (state: RootState, t: number) => {
+export function dragonFactorAt(state: RootState, t: number) {
   const sw = buffActive(state, 'SW', t);
   const aa = buffActive(state, 'AA', t);
   const cc = buffActive(state, 'CC', t);
   return sw && (aa || cc) ? 0.25 : sw || aa || cc ? 0.5 : 1;
-};
+}
+export function selectRemainingChannel(state: RootState, id: string) {
+  const cast = state.channels.active[id];
+  if (cast == null) return 0;
+  const base = abilityById(id).baseChannelMs ?? 0;
+  const dt = 50;
+  let t = cast,
+    done = 0;
+  while (done < base) {
+    const haste = selectTotalHasteAt(state, t);
+    const rate = id === 'FoF' ? haste / dragonFactorAt(state, t) : haste;
+    done += dt * rate;
+    t += dt;
+    if (t - cast > 600000) break;
+  }
+  return Math.max(0, t - state.now);
+}
 
-export const makeRemainingChannelSelector = (abilityId: string) => {
-  return (state: RootState): number => {
-    const cast = state.channels[abilityId as keyof typeof state.channels]?.castTime;
-    if (cast == null) return 0;
-    const base = abilityById(abilityId).baseChannelMs ?? 0;
-    const dt = 50;
-    let t = cast,
-      done = 0;
-    while (done < base) {
-      const haste = selectTotalHasteAt(state, t);
-      const factor = abilityId === 'FoF' ? dragonFactorAt(state, t) : 1;
-      const rate = haste / factor;
-      done += dt * rate;
-      t += dt;
-      if (t - cast > 600000) break;
-    }
-    return Math.max(0, t - state.now);
-  };
-};
-
-export const selectRemFoF = makeRemainingChannelSelector('FoF');
-export const selectRemCC = makeRemainingChannelSelector('CC');
-export const selectRemSW = makeRemainingChannelSelector('SW');
+export const selectRemFoF = (s: RootState) => selectRemainingChannel(s, 'FoF');
+export const selectRemCC = (s: RootState) => selectRemainingChannel(s, 'CC');
+export const selectRemSW = (s: RootState) => selectRemainingChannel(s, 'SW');

--- a/tests/channel_dynamic.spec.ts
+++ b/tests/channel_dynamic.spec.ts
@@ -4,8 +4,7 @@ import {
   cast,
   advanceTime,
   setGearRating,
-  selectRemFoF,
-  selectRemCC,
+  selectRemainingChannel,
 } from '../src/logic/dynamicEngine';
 
 let s: ReturnType<typeof createState>;
@@ -18,9 +17,9 @@ it('FoF channel updates when haste added mid-cast', () => {
   setGearRating(s, 0);
   cast(s, 'FoF');
   advanceTime(s, 1000);
-  const before = selectRemFoF(s);
+  const before = selectRemainingChannel(s, 'FoF');
   cast(s, 'BL');
-  expect(selectRemFoF(s)).toBeLessThan(before);
+  expect(selectRemainingChannel(s, 'FoF')).toBeLessThan(before);
 });
 
 it('FoF dragonFactor 0.25 live', () => {
@@ -28,23 +27,23 @@ it('FoF dragonFactor 0.25 live', () => {
   advanceTime(s, 200);
   cast(s, 'SW');
   cast(s, 'AA');
-  expect(selectRemFoF(s)).toBeLessThan(1100);
+  expect(selectRemainingChannel(s, 'FoF')).toBeLessThan(1100);
 });
 
 it('FoF channel updates when buffs dragged in', () => {
   setGearRating(s, 0);
   cast(s, 'FoF');
   advanceTime(s, 500);
-  const before = selectRemFoF(s);
+  const before = selectRemainingChannel(s, 'FoF');
   cast(s, 'SW');
   cast(s, 'AA');
-  expect(selectRemFoF(s)).toBeLessThan(before * 0.7);
+  expect(selectRemainingChannel(s, 'FoF')).toBeLessThan(before * 0.7);
 });
 
 it('CC channel reacts to Bloodlust added after cast', () => {
   cast(s, 'CC');
   advanceTime(s, 700);
-  const before = selectRemCC(s);
+  const before = selectRemainingChannel(s, 'CC');
   cast(s, 'BL');
-  expect(selectRemCC(s)).toBeLessThan(before);
+  expect(selectRemainingChannel(s, 'CC')).toBeLessThan(before);
 });

--- a/tests/channel_live.spec.ts
+++ b/tests/channel_live.spec.ts
@@ -4,8 +4,7 @@ import {
   cast,
   advanceTime,
   setGearRating,
-  selectRemFoF,
-  selectRemCC,
+  selectRemainingChannel,
 } from '../src/logic/dynamicEngine';
 
 const RATING_50 = 35829; // ~= 50% haste
@@ -20,24 +19,24 @@ it('FoF channel shrinks after adding haste', () => {
   setGearRating(s, 0);
   cast(s, 'FoF');
   advanceTime(s, 1000);
-  const before = selectRemFoF(s);
+  const before = selectRemainingChannel(s, 'FoF');
   cast(s, 'BL');
-  expect(selectRemFoF(s)).toBeLessThan(before);
+  expect(selectRemainingChannel(s, 'FoF')).toBeLessThan(before);
 });
 
 it('FoF reacts to dragonFactor 0.25', () => {
   cast(s, 'FoF');
   advanceTime(s, 200);
-  const before = selectRemFoF(s);
+  const before = selectRemainingChannel(s, 'FoF');
   cast(s, 'SW');
   cast(s, 'AA');
-  expect(selectRemFoF(s)).toBeLessThan(before * 0.6);
+  expect(selectRemainingChannel(s, 'FoF')).toBeLessThan(before * 0.6);
 });
 
 it('CC channel reacts to gear haste change', () => {
   cast(s, 'CC');
   advanceTime(s, 500);
-  const before = selectRemCC(s);
+  const before = selectRemainingChannel(s, 'CC');
   setGearRating(s, RATING_50);
-  expect(selectRemCC(s)).toBeLessThan(before);
+  expect(selectRemainingChannel(s, 'CC')).toBeLessThan(before);
 });


### PR DESCRIPTION
## Summary
- compute channel durations on-the-fly
- restructure channels slice to track only cast time
- update selectors and tests

## Testing
- `pnpm run test`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6882abac446c832f9a00f99fdfe6f98d