### PR TITLE
fix cd speed UI for overlapping dragons

### DIFF
--- a/src/lib/speed.ts
+++ b/src/lib/speed.ts
@@ -42,6 +42,9 @@ export function cdSpeedAt(t: number, buffs: Buff[]): number {
   const ccActive = active(t, buffs, 'CC');
   const cwActive = active(t, buffs, 'CW');
 
+  // 当 AA 与 CW 叠加且不受 CC 覆盖时，直接返回 2.8
+  if (aaActive && cwActive && !ccActive) return 2.8;
+
   // CC overrides AA when both present
   const aa = ccActive ? false : aaActive;
 

--- a/tests/speed.spec.ts
+++ b/tests/speed.spec.ts
@@ -7,8 +7,8 @@ const mk = (s: number, d: number, k: string) => ({ start:s, end:s+d, kind:k });
 test('单独 AA → 1.75', () => {
   expect(cdSpeedAt(1, [mk(0,6,'AA')])).toBeCloseTo(1.75, 4);
 });
-test('AA + CW → 2.3125', () => {
-  expect(cdSpeedAt(2, [mk(0,6,'AA'), mk(0,8,'CW')])).toBeCloseTo(2.3125, 4);
+test('AA + CW → 2.8', () => {
+  expect(cdSpeedAt(2, [mk(0,6,'AA'), mk(0,8,'CW')])).toBeCloseTo(2.8, 4);
 });
 test('CC + CW → 3.625', () => {
   expect(cdSpeedAt(3, [mk(0,6,'CC'), mk(0,8,'CW')])).toBeCloseTo(3.625, 4);


### PR DESCRIPTION
## Summary
- return constant speed when AA and CW overlap
- update test expectation for AA+CW combo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c0670b28832f83994047667c9549