### PR TITLE
Fix FoF dynamic channel timing

### DIFF
--- a/src/utils/calcDynamicEndTime.ts
+++ b/src/utils/calcDynamicEndTime.ts
@@ -1,0 +1,49 @@
+import { hasteAt } from '../lib/haste';
+
+export interface Buff {
+  start: number;
+  end: number;
+  key?: string;
+  multiplier?: number;
+}
+
+export function calcDynamicEndTime(
+  startTime: number,
+  baseCast: number,
+  buffs: Buff[],
+  blessingBuffs: Buff[],
+  rating: number,
+  fofBuffKeys: string[] = [],
+): number {
+  if (baseCast <= 0) return startTime;
+  const all = [...buffs, ...blessingBuffs];
+  const edges = Array.from(
+    new Set(all.flatMap(b => [b.start, b.end]).filter(t => t > startTime)),
+  ).sort((a, b) => a - b);
+  edges.push(Infinity);
+  let t = startTime;
+  let remain = baseCast;
+  for (const edge of edges) {
+    const haste = hasteAt(t, all, rating);
+    let dragon = 1;
+    if (fofBuffKeys.length) {
+      const active = buffs
+        .filter(b => fofBuffKeys.includes(b.key ?? '') && b.start <= t && t < b.end)
+        .map(b => b.key);
+      const hasAA = active.includes('AA_BD');
+      const hasSW = active.includes('SW_BD');
+      const hasCC = active.includes('CC_BD');
+      if (hasSW && (hasAA || hasCC)) dragon = 4;
+      else if (hasAA || hasSW || hasCC) dragon = 2;
+    }
+    const rate = haste * dragon;
+    const span = edge - t;
+    const consumed = span * rate;
+    if (consumed >= remain) {
+      return t + remain / rate;
+    }
+    remain -= consumed;
+    t = edge;
+  }
+  return t;
+}

--- a/tests/dynamic_cast.spec.ts
+++ b/tests/dynamic_cast.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { calcDynamicEndTime } from '../src/utils/calcDynamicEndTime';
+
+const BL = { key: 'BL', start: 1, end: 41, multiplier: 1.3 };
+
+describe('calcDynamicEndTime', () => {
+  it('FoF shortened by Bloodlust mid-cast', () => {
+    const end = calcDynamicEndTime(0, 4, [BL], [], 0, ['AA_BD','SW_BD','CC_BD']);
+    // 1s normal speed then haste 1.3x for remaining 3s => 1 + 3/1.3
+    expect(end).toBeCloseTo(1 + 3 / 1.3, 3);
+  });
+
+  it('dragon speed applies', () => {
+    const sw = { key: 'SW_BD', start: 0, end: 8 };
+    const end = calcDynamicEndTime(0, 4, [sw], [], 0, ['AA_BD','SW_BD','CC_BD']);
+    expect(end).toBeCloseTo(2, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- compute ability durations dynamically considering buffs
- add `calcDynamicEndTime` utility
- test dynamic cast computation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d23e6c08832fa17c90044fd65693