### PR TITLE
feature/new-dragon-sweep

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -305,11 +305,25 @@ export default function App() {
       viewStart + duration,
     ])).sort((a, b) => a - b);
     const res: TLItem[] = [];
+    const sweepAt = (t: number) => {
+      const sw = buffs.some(b => b.key === 'SW_BD' && b.start <= t && t < b.end);
+      const aa = buffs.some(b => b.key === 'AA_BD' && b.start <= t && t < b.end);
+      const cc = buffs.some(b => b.key === 'CC_BD' && b.start <= t && t < b.end);
+      if (!sw) return 0;
+      if (aa && !cc) return 3.0625;
+      if (cc && !aa) return 4.375;
+      if (aa && cc) return Math.max(3.0625, 4.375);
+      return 0;
+    };
     for (let i = 0; i < times.length - 1; i++) {
       const s = times[i];
       const e = times[i + 1];
-      const mult = hasteAt((s + e) / 2, all, stats.haste);
+      const mid = (s + e) / 2;
+      const mult = hasteAt(mid, all, stats.haste);
+      const sweep = sweepAt(mid);
+      const tick = Math.max(mult, sweep);
       const lbl = `${mult.toFixed(3).replace(/0+$/,'').replace(/\.$/,'')}×`;
+      const title = tick > mult ? `Tick ${tick.toFixed(2)}×` : lbl;
       res.push({
         id: 20000 + i,
         group: 1,
@@ -317,7 +331,7 @@ export default function App() {
         end: e,
         label: lbl,
         className: 'haste',
-        title: lbl,
+        title,
       });
     }
     return res;

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,7 +1,7 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
-import { hasCdSweep } from '../selectors/dragonSweep';
+import { sweepRate } from '../selectors/dragonSweep';
 
 export interface GearChange {
   start: number;
@@ -91,8 +91,8 @@ export function getEffectiveTickRate(
   const ability = abilityById(abilityId);
   if (ability.snapshot) return 1;
   const baseRate = selectTotalHasteAt(state, now);
-  const sweepRate = hasCdSweep(state, now) ? 1.8 : 0;
-  return Math.max(baseRate, sweepRate);
+  const sweep = sweepRate(state, now);
+  return Math.max(baseRate, sweep);
 }
 
 export function advanceTime(state: RootState, dt: number) {

--- a/src/selectors/dragonSweep.ts
+++ b/src/selectors/dragonSweep.ts
@@ -1,5 +1,15 @@
 import { buffActive } from '../logic/dynamicEngine';
 import type { RootState } from '../logic/dynamicEngine';
 
-export const hasCdSweep = (state: RootState, t: number) =>
-  buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
+export function sweepRate(state: RootState, t: number): number {
+  const sw = buffActive(state, 'SW', t);
+  const aa = buffActive(state, 'AA', t);
+  const cc = buffActive(state, 'CC', t);
+
+  if (!sw) return 0; // no sweep without SW
+
+  if (aa && !cc) return 3.0625; // SW + AA only
+  if (cc && !aa) return 4.375; // SW + CC only
+  if (aa && cc) return Math.max(3.0625, 4.375); // all three → 4.375
+  return 0;
+}

--- a/tests/dragon_sweep.spec.ts
+++ b/tests/dragon_sweep.spec.ts
@@ -1,19 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import { createState, cast, advanceTime, getCooldown } from '../src/logic/dynamicEngine';
 
-it('CD sweep only when AA+SW, not CC+SW', () => {
-  let s = createState();
-  cast(s, 'AA');
-  cast(s, 'SW');
-  cast(s, 'YH');
-  advanceTime(s, 5000);
-  expect(getCooldown(s, 'YH')).toBeLessThan(30000 - 5000 * 1.8 + 1);
+describe('dragon sweep tick rate', () => {
+  it('SW+AA gives 3.0625× tick rate', () => {
+    const s = createState();
+    cast(s, 'SW');
+    cast(s, 'AA');
+    cast(s, 'YH');
+    advanceTime(s, 4000);
+    expect(getCooldown(s, 'YH')).toBeCloseTo(30000 - 4000 * 3.0625, 0);
+  });
 
-  s = createState();
-  cast(s, 'CC');
-  cast(s, 'SW');
-  cast(s, 'YH');
-  advanceTime(s, 5000);
-  expect(getCooldown(s, 'YH')).toBeCloseTo(25000, 0);
+  it('SW+CC gives 4.375× tick rate', () => {
+    const s = createState();
+    cast(s, 'SW');
+    cast(s, 'CC');
+    cast(s, 'YH');
+    advanceTime(s, 2000);
+    expect(getCooldown(s, 'YH')).toBeCloseTo(30000 - 2000 * 4.375, 0);
+  });
 });
 

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -7,12 +7,12 @@ beforeEach(() => {
   state = createState();
 });
 
-it('AA+SW overlap sweeps 1.8s per s', () => {
+it('AA+SW overlap sweeps 3.0625s per s', () => {
   cast(state, 'AA');
   cast(state, 'SW');
   cast(state, 'YH');
   advanceTime(state, 5000);
-  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 1.8, 0);
+  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 3.0625, 0);
 });
 
 it('haste added mid-cd accelerates', () => {

--- a/tests/dynamic_cd_recalc.spec.ts
+++ b/tests/dynamic_cd_recalc.spec.ts
@@ -31,12 +31,12 @@ describe('dynamic cooldown recomputation', () => {
     expect(getCooldown(s, 'YH')).toBeLessThanOrEqual(original - 5000 * 0.3);
   });
 
-  it('AA+SW overlap sweep integrates 1.8× section', () => {
+  it('AA+SW overlap sweep integrates 3.0625× section', () => {
     cast(s, 'AA');
     cast(s, 'SW');
     cast(s, 'YH');
-    advanceTime(s, 25000);
-    const elapsed = 6000 * 1.8 + 19000 * 1; // AA 6s, rest normal
+    advanceTime(s, 10000);
+    const elapsed = 6000 * 3.0625 + 4000 * 1; // first 6s swept, rest normal
     expect(getCooldown(s, 'YH')).toBeCloseTo(30000 - elapsed, 0);
   });
 });


### PR DESCRIPTION
## Summary
- implement new sweepRate helper returning actual tick multiplier
- apply sweepRate in cooldown calculations
- show tick multiplier in haste tooltip
- update dragon sweep tests for new multipliers
- revise dynamic cooldown tests for new sweep rate

## Testing
- `pnpm run test`
- `pnpm run dev` *(fails: port busy but server started)*

------
https://chatgpt.com/codex/tasks/task_e_6883d8014b5c832fa1e19237314c0a2f