### PR TITLE
Update dragon sweep multipliers

### DIFF
--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,7 +1,6 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
-import { hasCdSweep } from '../selectors/dragonSweep';
 
 export interface GearChange {
   start: number;
@@ -90,9 +89,16 @@ export function getEffectiveTickRate(
 ): number {
   const ability = abilityById(abilityId);
   if (ability.snapshot) return 1;
-  const baseRate = selectTotalHasteAt(state, now);
-  const sweepRate = hasCdSweep(state, now) ? 1.8 : 0;
-  return Math.max(baseRate, sweepRate);
+  const base = selectTotalHasteAt(state, now);
+
+  const sw = buffActive(state, 'SW', now);
+  if (sw) {
+    const aa = buffActive(state, 'AA', now);
+    const cc = buffActive(state, 'CC', now);
+    const sweep = cc ? 4.375 : aa ? 3.0625 : 0;
+    return Math.max(base, sweep);
+  }
+  return base;
 }
 
 export function advanceTime(state: RootState, dt: number) {

--- a/src/selectors/dragonSweep.ts
+++ b/src/selectors/dragonSweep.ts
@@ -1,5 +1,7 @@
 import { buffActive } from '../logic/dynamicEngine';
 import type { RootState } from '../logic/dynamicEngine';
 
-export const hasCdSweep = (state: RootState, t: number) =>
-  buffActive(state, 'AA', t) && buffActive(state, 'SW', t);
+export const hasCdSweep = (state: RootState, t: number) => {
+  if (!buffActive(state, 'SW', t)) return false;
+  return buffActive(state, 'AA', t) || buffActive(state, 'CC', t);
+};

--- a/tests/dragon_sweep.spec.ts
+++ b/tests/dragon_sweep.spec.ts
@@ -1,19 +1,36 @@
-import { describe, it, expect } from 'vitest';
-import { createState, cast, advanceTime, getCooldown } from '../src/logic/dynamicEngine';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createState,
+  cast,
+  advanceTime,
+  selectRemainingCd,
+} from '../src/logic/dynamicEngine';
 
-it('CD sweep only when AA+SW, not CC+SW', () => {
-  let s = createState();
-  cast(s, 'AA');
-  cast(s, 'SW');
-  cast(s, 'YH');
-  advanceTime(s, 5000);
-  expect(getCooldown(s, 'YH')).toBeLessThan(30000 - 5000 * 1.8 + 1);
+let store: ReturnType<typeof createState>;
 
-  s = createState();
-  cast(s, 'CC');
-  cast(s, 'SW');
-  cast(s, 'YH');
-  advanceTime(s, 5000);
-  expect(getCooldown(s, 'YH')).toBeCloseTo(25000, 0);
+beforeEach(() => {
+  store = createState();
 });
 
+describe('dragon sweep cooldown', () => {
+  it('AA+SW sweeps 2.0625s CD per real second', () => {
+    cast(store, 'AA');
+    cast(store, 'SW');
+    cast(store, 'YH');
+    advanceTime(store, 4000);
+    const rem = selectRemainingCd(store, 'YH');
+    const expectedBurn = 4000 * 3.0625;
+    expect(rem).toBeCloseTo(30000 - expectedBurn, 0);
+  });
+
+  it('CC+SW sweeps 3.375s CD per real second', () => {
+    store = createState();
+    cast(store, 'CC');
+    cast(store, 'SW');
+    cast(store, 'YH');
+    advanceTime(store, 4000);
+    const rem = selectRemainingCd(store, 'YH');
+    const expectedBurn = 4000 * 4.375;
+    expect(rem).toBeCloseTo(30000 - expectedBurn, 0);
+  });
+});

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -7,12 +7,12 @@ beforeEach(() => {
   state = createState();
 });
 
-it('AA+SW overlap sweeps 1.8s per s', () => {
+it('AA+SW overlap sweeps 3.0625s per s', () => {
   cast(state, 'AA');
   cast(state, 'SW');
   cast(state, 'YH');
   advanceTime(state, 5000);
-  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 1.8, 0);
+  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 3.0625, 0);
 });
 
 it('haste added mid-cd accelerates', () => {

--- a/tests/dynamic_cd_recalc.spec.ts
+++ b/tests/dynamic_cd_recalc.spec.ts
@@ -31,12 +31,11 @@ describe('dynamic cooldown recomputation', () => {
     expect(getCooldown(s, 'YH')).toBeLessThanOrEqual(original - 5000 * 0.3);
   });
 
-  it('AA+SW overlap sweep integrates 1.8× section', () => {
+  it('AA+SW overlap sweep integrates new multipliers', () => {
     cast(s, 'AA');
     cast(s, 'SW');
     cast(s, 'YH');
     advanceTime(s, 25000);
-    const elapsed = 6000 * 1.8 + 19000 * 1; // AA 6s, rest normal
-    expect(getCooldown(s, 'YH')).toBeCloseTo(30000 - elapsed, 0);
+    expect(getCooldown(s, 'YH')).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- adjust cooldown sweep rates for SW overlaps with AA or CC
- update dragon sweep selector
- add regression tests for new sweep rates

## Testing
- `pnpm run test`
- `pnpm run dev` *(fails: just used for manual check)*

------
https://chatgpt.com/codex/tasks/task_e_688467e43674832f87aba41050128bb5