### PR TITLE
Fix dragon sweep rate and UI label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import { getEndAt } from './utils/getEndAt';
 import { GRID_STEP_MS, } from './constants/time';
 import { getNextAvailableCastTime, roundToGridMs } from './utils/timeline';
 import { buildTimeline } from './lib/simulator';
-import { cdSpeedAt } from './lib/speed';
+import { sweepRate } from './utils/dragonSweep';
 import { fmt } from './util/fmt';
 import { computeBlessingSegments } from './util/blessingSegments';
 import { SkillCast } from './types';
@@ -255,7 +255,17 @@ export default function App() {
     for (let i = 0; i < times.length - 1; i++) {
       const s = times[i];
       const e = times[i + 1];
-      const extra = cdSpeedAt((s + e) / 2, buffs) - 1;
+      const mid = (s + e) / 2;
+      const base = hasteAt(mid, [...buffs, ...blessingBuffs], stats.haste);
+      const rate = Math.max(base, sweepRate({
+        now: 0,
+        gear: [],
+        buffs,
+        snapshotCds: [],
+        dynamicCasts: [],
+        channels: { active: {} },
+      } as any, mid));
+      const extra = rate - 1;
       if (extra > 0) {
         res.push({
           id: 10000 + i,

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,5 +1,6 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
+import { sweepRate } from '../utils/dragonSweep';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
 
 export interface GearChange {
@@ -90,15 +91,8 @@ export function getEffectiveTickRate(
   const ability = abilityById(abilityId);
   if (ability.snapshot) return 1;
   const base = selectTotalHasteAt(state, now);
-
-  const sw = buffActive(state, 'SW', now);
-  if (sw) {
-    const aa = buffActive(state, 'AA', now);
-    const cc = buffActive(state, 'CC', now);
-    const sweep = cc ? 4.375 : aa ? 3.0625 : 0;
-    return Math.max(base, sweep);
-  }
-  return base;
+  const sweep = sweepRate(state, now);
+  return Math.max(base, sweep);
 }
 
 export function advanceTime(state: RootState, dt: number) {

--- a/src/utils/dragonSweep.ts
+++ b/src/utils/dragonSweep.ts
@@ -1,0 +1,12 @@
+import { buffActive } from '../selectors/buff';
+import type { RootState } from '../logic/dynamicEngine';
+
+export function sweepRate(state: RootState, t: number): number {
+  const sw = buffActive(state, 'SW', t);
+  if (!sw) return 0;
+  const aa = buffActive(state, 'AA', t);
+  const cc = buffActive(state, 'CC', t);
+  if (cc) return 4.375;
+  if (aa) return 3.0625;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `sweepRate` util for dragon sweep tick rate
- use `sweepRate` in cooldown logic
- show dynamic sweep rate on timeline

## Testing
- `pnpm run test`
- `pnpm run dev` *(server starts)*


------
https://chatgpt.com/codex/tasks/task_e_68846decd4b4832fae0a9797d34c36ea