### PR TITLE
Fix dragon sweep speed & label

### DIFF
--- a/src/lib/speed.ts
+++ b/src/lib/speed.ts
@@ -42,19 +42,15 @@ export function cdSpeedAt(t: number, buffs: Buff[]): number {
   const ccActive = active(t, buffs, 'CC');
   const cwActive = active(t, buffs, 'CW');
 
-  // 当 AA 与 CW 叠加且不受 CC 覆盖时，直接返回 2.8
-  if (aaActive && cwActive && !ccActive) return 2.8;
+  if (cwActive) {
+    if (ccActive) return 4.375;
+    if (aaActive) return 3.0625;
+    return 1.75;
+  }
 
-  // CC overrides AA when both present
-  const aa = ccActive ? false : aaActive;
-
-  let extra = 0;
-  if (cwActive && ccActive) extra = 1.5 * 1.75;
-  else if (cwActive && aa) extra = 0.75 * 1.75;
-  else if (ccActive) extra = 1.5;
-  else if (aa || cwActive) extra = 0.75;
-
-  return 1 + extra;
+  if (ccActive) return 2.5;
+  if (aaActive) return 1.75;
+  return 1;
 }
 
 // END_PATCH

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,6 +1,7 @@
 import { abilityById } from '../constants/abilities';
 import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
+import { sweepRate } from '../utils/dragonSweep';
 
 export interface GearChange {
   start: number;
@@ -90,15 +91,8 @@ export function getEffectiveTickRate(
   const ability = abilityById(abilityId);
   if (ability.snapshot) return 1;
   const base = selectTotalHasteAt(state, now);
-
-  const sw = buffActive(state, 'SW', now);
-  if (sw) {
-    const aa = buffActive(state, 'AA', now);
-    const cc = buffActive(state, 'CC', now);
-    const sweep = cc ? 4.375 : aa ? 3.0625 : 0;
-    return Math.max(base, sweep);
-  }
-  return base;
+  const sweep = sweepRate(state, now);
+  return Math.max(base, sweep);
 }
 
 export function advanceTime(state: RootState, dt: number) {

--- a/src/utils/dragonSweep.ts
+++ b/src/utils/dragonSweep.ts
@@ -1,0 +1,10 @@
+import { RootState, buffActive } from '../logic/dynamicEngine';
+
+export function sweepRate(state: RootState, t: number): number {
+  if (!buffActive(state, 'SW', t)) return 0;
+  const cc = buffActive(state, 'CC', t);
+  if (cc) return 4.375;
+  const aa = buffActive(state, 'AA', t);
+  if (aa) return 3.0625;
+  return 0;
+}

--- a/tests/dragonSweepLabel.spec.ts
+++ b/tests/dragonSweepLabel.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { cdSpeedAt } from '../src/lib/speed';
+
+const mk = (s:number,d:number,k:string)=>({start:s,end:s+d,kind:k});
+
+describe('dragon sweep label', () => {
+  it('AA+SW shows +2.06', () => {
+    const rate = cdSpeedAt(2, [mk(0,6,'AA'), mk(0,8,'CW')]);
+    const extra = (rate - 1).toFixed(2);
+    expect(extra).toBe('2.06');
+  });
+
+  it('CC+SW shows +3.38', () => {
+    const rate = cdSpeedAt(2, [mk(0,6,'CC'), mk(0,8,'CW')]);
+    const extra = (rate - 1).toFixed(2);
+    expect(extra).toBe('3.38');
+  });
+});

--- a/tests/speed.spec.ts
+++ b/tests/speed.spec.ts
@@ -7,11 +7,11 @@ const mk = (s: number, d: number, k: string) => ({ start:s, end:s+d, kind:k });
 test('单独 AA → 1.75', () => {
   expect(cdSpeedAt(1, [mk(0,6,'AA')])).toBeCloseTo(1.75, 4);
 });
-test('AA + CW → 2.8', () => {
-  expect(cdSpeedAt(2, [mk(0,6,'AA'), mk(0,8,'CW')])).toBeCloseTo(2.8, 4);
+test('AA + CW → 3.0625', () => {
+  expect(cdSpeedAt(2, [mk(0,6,'AA'), mk(0,8,'CW')])).toBeCloseTo(3.0625, 4);
 });
-test('CC + CW → 3.625', () => {
-  expect(cdSpeedAt(3, [mk(0,6,'CC'), mk(0,8,'CW')])).toBeCloseTo(3.625, 4);
+test('CC + CW → 4.375', () => {
+  expect(cdSpeedAt(3, [mk(0,6,'CC'), mk(0,8,'CW')])).toBeCloseTo(4.375, 4);
 });
 test('CC + AA → 2.5', () => {
   expect(cdSpeedAt(4, [mk(0,6,'CC'), mk(0,6,'AA')])).toBeCloseTo(2.5, 4);


### PR DESCRIPTION
## Summary
- update tick rate logic for dragon sweep
- show dynamic cooldown text with new rates
- add dragon sweep helpers & tests

## Testing
- `pnpm run test`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68846decd4b4832fae0a9797d34c36ea