### PR TITLE
feat(skills): add BLK_HL, SCK, SCK_HL to minorFiller

### DIFF
--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -21,6 +21,19 @@ export const ABILITIES: Record<string, Ability> = {
   WU: { id: 'WU', cooldownMs: 25000, snapshot: true },
   CC: { id: 'CC', cooldownMs: 90000, baseChannelMs: 1500, channelDynamic: true },
   BL: { id: 'BL', cooldownMs: 0 },
+  SCK: {
+    id: 'SCK',
+    cooldownMs: 0,
+    baseChannelMs: 1500,
+    channelDynamic: true,
+  },
+  SCK_HL: {
+    id: 'SCK_HL',
+    cooldownMs: 0,
+    baseChannelMs: 1500,
+    channelDynamic: true,
+  },
+  BLK_HL: { id: 'BLK_HL', cooldownMs: 0 },
 };
 
 export function abilityById(id: string): Ability {

--- a/src/constants/icons.ts
+++ b/src/constants/icons.ts
@@ -8,6 +8,9 @@ import AA from '../assets/abilityIcons/inv_hand_1h_artifactskywall_d_01.jpg';
 import SEF from '../assets/abilityIcons/spell_nature_giftofthewild.jpg';
 import FoF from '../assets/abilityIcons/monk_ability_fistoffury.jpg';
 import BL from '../assets/abilityIcons/spell_orc_berserker.jpg';
+import SCK from '../assets/abilityIcons/ability_monk_cranekick_new.jpg';
+import SCK_HL from '../assets/abilityIcons/ability_monk_cranekick_new_HL.jpg';
+import BLK_HL from '../assets/abilityIcons/ability_monk_roundhousekick_HL.jpg';
 
 export const ABILITY_ICON_MAP: Record<string, {src: string; abbr: string}> = {
   WU:  {src: WU,  abbr: 'WU'},
@@ -20,4 +23,7 @@ export const ABILITY_ICON_MAP: Record<string, {src: string; abbr: string}> = {
   SEF: {src: SEF, abbr: 'SEF'},
   FoF: {src: FoF, abbr: 'FoF'},
   BL:  {src: BL,  abbr: 'BL'},
+  SCK: {src: SCK, abbr: 'SCK'},
+  SCK_HL: {src: SCK_HL, abbr: 'SCKH'},
+  BLK_HL: {src: BLK_HL, abbr: 'BLK'},
 };

--- a/src/selectors/channel.ts
+++ b/src/selectors/channel.ts
@@ -13,13 +13,19 @@ export function dragonFactorAt(state: RootState, t: number) {
 export function selectRemainingChannel(state: RootState, id: string) {
   const cast = state.channels.active[id];
   if (cast == null) return 0;
-  const base = abilityById(id).baseChannelMs ?? 0;
+  const ability = abilityById(id);
+  const base = ability.baseChannelMs ?? 0;
   const dt = 50;
   let t = cast;
   let done = 0;
   while (done < base) {
     const haste = selectTotalHasteAt(state, t);
-    const rate = id === 'FoF' ? haste / dragonFactorAt(state, t) : haste;
+    const rate =
+      id === 'FoF'
+        ? haste / dragonFactorAt(state, t)
+        : ability.channelDynamic
+          ? haste
+          : 0;
     done += dt * rate;
     t += dt;
     if (t - cast > 600000) break;

--- a/tests/channel_live.spec.ts
+++ b/tests/channel_live.spec.ts
@@ -4,6 +4,7 @@ import {
   cast,
   advanceTime,
   setGearHastePercent,
+  selectRemainingChannel,
   selectRemFoF,
   selectRemCC,
 } from '../src/logic/dynamicEngine';
@@ -39,4 +40,20 @@ it('CC channel reacts to gear haste change', () => {
   const before = selectRemCC(s);
   setGearHastePercent(s, 0.50);
   expect(selectRemCC(s)).toBeLessThan(before);
+});
+
+it('SCK channel = 1.5s/haste', () => {
+  setGearHastePercent(s, 0.20); // 1.2×
+  cast(s, 'SCK');
+  const rem = selectRemainingChannel(s, 'SCK');
+  expect(rem).toBeCloseTo(1500 / 1.2, 0);
+});
+
+it('SCK_HL channel live updates', () => {
+  setGearHastePercent(s, 0);
+  cast(s, 'SCK_HL');
+  advanceTime(s, 500);
+  const before = selectRemainingChannel(s, 'SCK_HL');
+  setGearHastePercent(s, 0.50); // 1.5×
+  expect(selectRemainingChannel(s, 'SCK_HL')).toBeLessThan(before);
 });


### PR DESCRIPTION
## Summary
- add BLK_HL, SCK, and SCK_HL abilities
- map new icons for the new abilities
- compute channel time using `channelDynamic` flag
- test SCK and SCK_HL channel behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884f929b4c0832fbdb07a0792c5ca7d