### PR TITLE
Add minor filler abilities

### DIFF
--- a/src/components/AbilityPalette.tsx
+++ b/src/components/AbilityPalette.tsx
@@ -20,6 +20,9 @@ const ROW_MAP: Record<WWKey, TimelineRow> = {
   WU: 'majorFiller',
   TP: 'minorFiller',
   BOK: 'minorFiller',
+  SCK: 'minorFiller',
+  SCK_HL: 'minorFiller',
+  BLK_HL: 'minorFiller',
   BL: 'majorCd', // put BL with major cds
 };
 

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -1,9 +1,12 @@
+import { TimelineRow } from './timelineRows';
+
 export interface Ability {
   id: string;
   cooldownMs: number;
   snapshot?: boolean;
   baseChannelMs?: number;
   channelDynamic?: boolean;
+  row?: TimelineRow;
 }
 
 export const ABILITIES: Record<string, Ability> = {
@@ -26,14 +29,16 @@ export const ABILITIES: Record<string, Ability> = {
     cooldownMs: 0,
     baseChannelMs: 1500,
     channelDynamic: true,
+    row: 'minorFiller',
   },
   SCK_HL: {
     id: 'SCK_HL',
     cooldownMs: 0,
     baseChannelMs: 1500,
     channelDynamic: true,
+    row: 'minorFiller',
   },
-  BLK_HL: { id: 'BLK_HL', cooldownMs: 0 },
+  BLK_HL: { id: 'BLK_HL', cooldownMs: 0, row: 'minorFiller' },
 };
 
 export function abilityById(id: string): Ability {

--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -297,5 +297,31 @@
     ],
     "gcd": 1,
     "cooldown": 90
+  },
+  {
+    "name": "SCK",
+    "id": 999996,
+    "effects": [
+      {}
+    ],
+    "gcd": 1,
+    "cast": 1.5
+  },
+  {
+    "name": "SCK_HL",
+    "id": 999995,
+    "effects": [
+      {}
+    ],
+    "gcd": 1,
+    "cast": 1.5
+  },
+  {
+    "name": "BLK_HL",
+    "id": 999997,
+    "effects": [
+      {}
+    ],
+    "gcd": 1
   }
 ]

--- a/src/jobs/windwalker.ts
+++ b/src/jobs/windwalker.ts
@@ -12,11 +12,14 @@ export const WW = {
   RSK: 107428,
   FoF: 113656,
   BL: 999998,
+  BLK_HL: 999997,
+  SCK: 999996,
+  SCK_HL: 999995,
 } as const;
 
 export type WWKey = keyof typeof WW;
 
-const HASTED: WWKey[] = ['RSK', 'FoF', 'WU'];
+const HASTED: WWKey[] = ['RSK', 'FoF', 'WU', 'SCK', 'SCK_HL'];
 
 export const wwData = (haste: number) =>
   Object.fromEntries(

--- a/tests/ui_palette.spec.tsx
+++ b/tests/ui_palette.spec.tsx
@@ -26,4 +26,22 @@ describe('AbilityPalette', () => {
     rows.forEach(row => expect(row.classList.contains('ability-row')).toBe(true));
     root.unmount();
   });
+
+  it('shows BLK_HL, SCK, SCK_HL in minorFiller row', async () => {
+    const abilities = wwData(0);
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    const root = createRoot(div);
+    await act(async () => {
+      root.render(<AbilityPalette abilities={abilities} onUse={() => {}} />);
+    });
+    const minorRow = div.querySelector('[data-row="minorFiller"]');
+    expect(minorRow).toBeTruthy();
+    const imgs = minorRow!.querySelectorAll('img');
+    const alts = Array.from(imgs).map(i => i.getAttribute('alt'));
+    expect(alts).toContain('BLK_HL');
+    expect(alts).toContain('SCK');
+    expect(alts).toContain('SCK_HL');
+    root.unmount();
+  });
 });


### PR DESCRIPTION
## Summary
- include BLK_HL, SCK and SCK_HL in WW data and constants
- expose new abilities in ability palette
- map new icons
- add regression test for minorFiller row

## Testing
- `pnpm run test`
- `pnpm run dev` *(fails: [Ctrl+C], ran briefly)*

------
https://chatgpt.com/codex/tasks/task_e_6884fb87eea4832fa7c3bdbf44b96e6e