### PR TITLE
Fix blackoutkick cooldown and lighten channel guides

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -20,7 +20,7 @@ export interface TLItem {
 }
 
 import { t } from '../i18n/en';
-import { GUIDE_COLOR } from '../constants/colors';
+import { GUIDE_COLOR, GUIDE_BORDER_COLOR } from '../constants/colors';
 
 const groups = [
   'Haste',
@@ -196,7 +196,9 @@ export const Timeline = ({
         className: [it.className, it.type === 'guide' ? 'event-guide' : ''].filter(Boolean).join(' '),
         ...(it.stacks ? { stacks: it.stacks } : {}),
         ...(it.title ? { title: it.title } : {}),
-        style: it.type === 'guide' ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#fff` : undefined,
+        style: it.type === 'guide'
+          ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_BORDER_COLOR};color:#fff`
+          : undefined,
       })),
     );
   }, [items]);

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -33,6 +33,13 @@ export const ABILITIES: Record<string, Ability> = {
     cooldownMs: 0,
     row: 'minorFiller',
   },
+  BOK: {
+    id: 'BOK',
+    name: 'Blackout Kick',
+    iconKey: 'BOK',
+    cooldownMs: 0,
+    row: 'minorFiller',
+  },
   SCK: {
     id: 'SCK',
     name: 'Spinning Crane Kick',

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,1 +1,2 @@
-export const GUIDE_COLOR = '#003377';
+export const GUIDE_COLOR = 'rgba(96, 160, 255, 0.4)';
+export const GUIDE_BORDER_COLOR = 'rgba(96, 160, 255, 0.6)';

--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -45,7 +45,7 @@
     },
     "range": 5,
     "gcd": 1.5,
-    "cooldown": 3
+    "cooldown": 0
   },
   {
     "name": "Flying Serpent Kick",

--- a/src/index.css
+++ b/src/index.css
@@ -58,8 +58,8 @@ body.light {
 }
 
 .vis-item.event-guide {
-  background-color: #003377;
-  border-color: #003377;
+  background-color: rgba(96, 160, 255, 0.4);
+  border-color: rgba(96, 160, 255, 0.6);
   color: #fff;
 }
 .vis-item.event-guide .vis-item-content {


### PR DESCRIPTION
## Summary
- remove cooldown from Blackout Kick
- show channel bars with lighter blue color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855a1dee60832fb068d55ef9f32cea