### PR TITLE
Fix BLK_HL chi cost & SEF extension

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,36 +19,6 @@ import { AbilityPalette } from './components/AbilityPalette';
 import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 
-const getOriginalChiCost = (key: WWKey): number => {
-  switch (key) {
-    case 'TP':   return 0;
-    case 'BOK':  return 1;
-    case 'RSK':  return 2;
-    case 'FoF':  return 3;
-    case 'SCK':  return 2;
-    case 'AA':   return 2;
-    case 'BLK_HL': return 1;
-    case 'SCK_HL': return 2;
-    default:      return 0;
-  }
-};
-
-const getActualChiCost = (key: WWKey, sefActive: boolean): number => {
-  if (key === 'SCK_HL') return 0;
-  const base = getOriginalChiCost(key);
-  return sefActive ? Math.max(base - 1, 0) : base;
-};
-
-const SEF_EXTENSION_COST_MAP: Record<WWKey, number> = {
-  BLK_HL: 1,
-  SCK_HL: 2,
-  RSK: 2,
-  FoF: 3,
-  AA: 2,
-  SCK: 2,
-  BOK: 1,
-  TP: 0,
-};
 
 interface CalcBuff {
   id: number;
@@ -128,21 +98,21 @@ function recomputeTimeline(
     });
     const notReady = overlaps.length >= maxCharges;
     const sefActiveBuff = buffs.find(b => b.key === 'SEF' && b.end > it.start);
-    const sefActive = !!sefActiveBuff;
-    const lowChi = chi < getActualChiCost(key, sefActive);
+    const origCost = getOriginalChiCost(key);
+    const actualCost = getActualChiCost(key, buffs, it.start);
+    const lowChi = chi < actualCost;
     if (idx >= 0) {
       let cls = (items[idx].className || '').replace('warning', '').trim();
       if (notReady || lowChi) cls = (cls + ' warning').trim();
       items[idx] = { ...items[idx], className: cls };
     }
 
-    const actualCost = getActualChiCost(key, sefActive);
-    const chiGain = key === 'TP' ? 2 : key === 'SEF' ? 2 : key === 'BLK_HL' ? 1 : 0;
+    const chiGain = key === 'TP' ? 2 : key === 'SEF' ? 2 : 0;
     if (actualCost > 0) chi = Math.max(0, chi - actualCost);
+    if (key === 'BLK_HL') chi += 1;
     chi = Math.min(6, chi + chiGain);
 
-    const sefChi = SEF_EXTENSION_COST_MAP[key] || 0;
-    if (sefActiveBuff && sefChi > 0) sefActiveBuff.end += 0.25 * sefChi;
+    if (sefActiveBuff && origCost > 0) sefActiveBuff.end += 0.25 * origCost;
 
     if (key === 'AA') {
       buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 5, src: it.id });
@@ -270,12 +240,11 @@ export default function App() {
 
     const originalCost = getOriginalChiCost(key);
     const sefActiveBuff = buffs.find(b => b.key === 'SEF' && b.end > now);
-    const sefActive = !!sefActiveBuff;
-    const actualCost = getActualChiCost(key, sefActive);
+    const actualCost = getActualChiCost(key, buffs, now);
     let chiGain = 0;
     if (key === 'TP') chiGain = 2;
     else if (key === 'SEF') chiGain = 2;
-    else if (key === 'BLK_HL') chiGain = 1;
+    
 
     if (actualCost > 0 && chi < actualCost) {
       alert('Chi不足，无法施放技能');
@@ -358,9 +327,8 @@ export default function App() {
     if (actualCost > 0) {
       dispatch(spendChi(actualCost));
     }
-    const sefChiCount = SEF_EXTENSION_COST_MAP[key] || 0;
-    if (sefActiveBuff && sefChiCount > 0) {
-      extension = 0.25 * sefChiCount;
+    if (sefActiveBuff && originalCost > 0) {
+      extension = 0.25 * originalCost;
       setBuffs(bs =>
         bs.map(b =>
           b.key === 'SEF' && b.end > now ? { ...b, end: b.end + extension } : b
@@ -369,6 +337,9 @@ export default function App() {
     }
     if (chiGain > 0) {
       dispatch(gainChi(chiGain));
+    }
+    if (key === 'BLK_HL') {
+      dispatch(gainChi(1));
     }
 
     console.log(

--- a/src/utils/chiCost.ts
+++ b/src/utils/chiCost.ts
@@ -1,0 +1,22 @@
+export interface Buff { key: string; start: number; end: number }
+
+export function getOriginalChiCost(key: string): number {
+  switch (key) {
+    case 'TP': return 0;
+    case 'BOK': return 1;
+    case 'RSK': return 2;
+    case 'FoF': return 3;
+    case 'SCK': return 2;
+    case 'AA': return 2;
+    case 'BLK_HL': return 1;
+    case 'SCK_HL': return 2;
+    default: return 0;
+  }
+}
+
+export function getActualChiCost(key: string, buffs: Buff[], now: number): number {
+  if (key === 'BLK_HL' || key === 'SCK_HL') return 0;
+  const orig = getOriginalChiCost(key);
+  const sefActive = buffs.some(b => b.key === 'SEF' && b.end > now);
+  return sefActive && orig > 0 ? Math.max(0, orig - 1) : orig;
+}

--- a/tests/chi_sef.spec.ts
+++ b/tests/chi_sef.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getOriginalChiCost, getActualChiCost } from '../src/utils/chiCost';
+
+describe('BLK_HL chi + SEF', () => {
+  it('BLK_HL costs 0 Chi, gives 1 Chi, extends SEF by 0.25s', () => {
+    const buffs = [{ key: 'SEF', start: 0, end: 10 }];
+    const now = 0;
+    const orig = getOriginalChiCost('BLK_HL');
+    const actual = getActualChiCost('BLK_HL', buffs as any, now);
+    expect(orig).toBe(1);
+    expect(actual).toBe(0);
+    let chi = 2;
+    if (actual > 0) chi -= actual;
+    if ('BLK_HL' === 'BLK_HL') chi += 1;
+    const extension = 0.25 * orig;
+    buffs[0].end += extension;
+    expect(chi).toBe(3);
+    expect(buffs[0].end).toBeCloseTo(10.25, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- make chi cost helpers with BLK_HL cost 0 when spending
- adjust chi spend/gain logic and SEF extension
- add unit test for BLK_HL chi and SEF buff logic

## Testing
- `pnpm run test`
- `pnpm run dev` *(started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_68855dba4ad4832fb9c5e37b88d0aba1