### PR TITLE
Fix SCK_HL chi behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/channel_dynamic.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx",
+    "test": "vitest run src/__tests__ tests/cd.spec.ts tests/speed.spec.ts tests/timeline.spec.ts tests/haste.spec.ts tests/cdSnapshot.spec.ts tests/haste_cooldown.spec.ts tests/blessing.spec.ts tests/blessing_haste.spec.ts tests/dragon_sync.spec.ts tests/dynamic_cd_recalc.spec.ts tests/channel_dynamic.spec.ts tests/dragon_sweep.spec.ts tests/ui_palette.spec.tsx tests/chi_sef.spec.ts",
     "test:mocha": "mocha build/tests/**/*.js",
     "lint": "echo lint"
   },

--- a/src/utils/chiCost.ts
+++ b/src/utils/chiCost.ts
@@ -19,6 +19,10 @@ export function getOriginalChiCost(key: string): number {
 
 export function getActualChiCost(key: string, buffs: Buff[], now: number): number {
   if (key === 'BLK_HL') return 0;
+  if (key === 'SCK_HL') {
+    // SCK_HL never costs Chi
+    return 0;
+  }
   const orig = getOriginalChiCost(key);
   const sefActive = buffs.some(b => b.key === 'SEF' && b.end > now);
   return sefActive && orig > 0 ? Math.max(0, orig - 1) : orig;

--- a/tests/chi_sef.spec.ts
+++ b/tests/chi_sef.spec.ts
@@ -23,4 +23,25 @@ describe('BLK_HL chi and SEF extension', () => {
     expect(chi).toBe(3);
     expect(sef.end).toBeCloseTo(15.25, 3);
   });
+
+  it('SCK_HL does not change Chi but extends SEF by 0.5s', () => {
+    const now = 0;
+    const sef: Buff = { key: 'SEF', end: 15 };
+    const buffs: Buff[] = [sef];
+
+    const original = getOriginalChiCost('SCK_HL');
+    expect(original).toBe(2);
+
+    const actual = getActualChiCost('SCK_HL', buffs, now);
+    expect(actual).toBe(0);
+
+    let chi = 2;
+    if (actual > 0) chi -= actual;
+    if (buffs.find(b => b.key === 'SEF' && b.end > now) && original > 0) {
+      sef.end += 0.25 * original;
+    }
+
+    expect(chi).toBe(2);
+    expect(sef.end).toBeCloseTo(15.5, 3);
+  });
 });


### PR DESCRIPTION
## Summary
- make `getActualChiCost` return 0 for `SCK_HL`
- extend SEF buff by 0.5s when casting SCK_HL via unit test
- run vitest on additional test file

## Testing
- `pnpm run test`
- `timeout 2 pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688566eaaddc832faff076484ff19a38