### PR TITLE
Redesigned layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -628,7 +628,8 @@ export default function App() {
     setStats(s => ({ ...s, [field]: value }));
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="app-layout">
+      <aside className="sidebar p-4 space-y-4">
       <h1 className="text-xl font-bold">{t('踏风排轴器')}</h1>
       <h1 className="text-xl">{t('Boss时间轴选项')}</h1>
       <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
@@ -729,23 +730,25 @@ export default function App() {
           </div>
         );
       })()}
-
-      <Timeline
-        items={[...hasteItems, ...items, ...buffItems, ...cdBars]}
-        start={viewStart}
-        end={viewStart + duration}
-        cursor={time}
-        cds={cdLines}
-        showCD={showCD}
-        onCursorChange={setTime}
-        onRangeChange={(s, e) => {
-          setViewStart(s);
-          setDuration(e - s);
-        }}
-        onItemMove={moveItem}
-        onItemContext={contextItem}
-        onItemClick={selectItem}
-      />
+      </aside>
+      <main className="timeline-container">
+        <Timeline
+          items={[...hasteItems, ...items, ...buffItems, ...cdBars]}
+          start={viewStart}
+          end={viewStart + duration}
+          cursor={time}
+          cds={cdLines}
+          showCD={showCD}
+          onCursorChange={setTime}
+          onRangeChange={(s, e) => {
+            setViewStart(s);
+            setDuration(e - s);
+          }}
+          onItemMove={moveItem}
+          onItemContext={contextItem}
+          onItemClick={selectItem}
+        />
+      </main>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,30 @@ body.light {
 .ability-row::-webkit-scrollbar {
   height: 6px;
 }
+
+/* layout containers */
+.app-layout {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+}
+
+.sidebar {
+  flex: 0 0 25%;
+  overflow-y: auto;
+}
+
+.timeline-container {
+  flex: 1;
+  overflow: auto;
+}
+
+/* larger timeline rows */
+.vis-item {
+  height: 48px;
+  line-height: 48px;
+}
+
+.vis-group {
+  height: 48px;
+}


### PR DESCRIPTION
## Summary
- structure layout with sidebar and timeline areas
- make sidebar 25% width and timeline 75%
- enlarge timeline row height

## Testing
- `pnpm run dev` *(hit Ctrl+C to stop)*

------
https://chatgpt.com/codex/tasks/task_e_68856f324bf0832fada7da2810595308