### PR TITLE
feat(ui): auto-resize timeline height

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AbilityPalette } from './components/AbilityPalette';
 import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 import { getOriginalChiCost, getActualChiCost } from './utils/chiCost';
+import { ROW_HEIGHT, ROW_COUNT, HEADER_HEIGHT } from './constants/timelineLayout';
 
 interface CalcBuff {
   id: number;
@@ -627,6 +628,8 @@ export default function App() {
   const update = (field: string, value: number) =>
     setStats(s => ({ ...s, [field]: value }));
 
+  const containerHeight = ROW_HEIGHT * ROW_COUNT + HEADER_HEIGHT;
+
   return (
     <div className="app-layout">
       <aside className="sidebar p-4 space-y-4">
@@ -731,7 +734,10 @@ export default function App() {
         );
       })()}
       </aside>
-      <main className="timeline-container">
+      <main
+        className="timeline-container"
+        style={{ height: containerHeight }}
+      >
         <Timeline
           items={[...hasteItems, ...items, ...buffItems, ...cdBars]}
           start={viewStart}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { DataSet, Timeline as VisTimeline } from "vis-timeline/standalone";
 import type { DataItem, DataGroup } from "vis-timeline";
 import { GRID_STEP_MS } from "../constants/time";
+import { ROW_HEIGHT, ROW_COUNT, HEADER_HEIGHT } from "../constants/timelineLayout";
 
 // Item displayed on the timeline. `end` is optional so we can draw range
 // bars (used for cooldown visualization).
@@ -114,7 +115,7 @@ export const Timeline = ({
       groupDS.current,
       {
         stack: false,
-        height: "400px",
+        height: ROW_HEIGHT * ROW_COUNT + HEADER_HEIGHT + 'px',
         align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),

--- a/src/constants/timelineLayout.ts
+++ b/src/constants/timelineLayout.ts
@@ -1,0 +1,5 @@
+import { TIMELINE_ROW_ORDER } from './timelineRows';
+
+export const ROW_HEIGHT = 48; // px
+export const ROW_COUNT = TIMELINE_ROW_ORDER.length;
+export const HEADER_HEIGHT = 40; // px for group labels

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,8 @@ body.light {
 /* layout containers */
 .app-layout {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   width: 100%;
 }
 
@@ -103,8 +104,8 @@ body.light {
 }
 
 .timeline-container {
-  flex: 1;
-  overflow: auto;
+  width: 75%;
+  overflow-y: auto;
 }
 
 /* larger timeline rows */


### PR DESCRIPTION
## Summary
- let the timeline container resize itself instead of being fixed
- expose timeline layout constants
- compute container height dynamically using row height and row count

## Testing
- `npm test`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6885742a4554832fa873351796b2d086