### PR TITLE
Auto-resize timeline container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Timeline, TLItem } from './components/Timeline';
 import { wwData, WWKey } from './jobs/windwalker';
 import { ratingToHaste, hasteAt } from './lib/haste';
 import { calcDynamicEndTime } from './utils/calcDynamicEndTime';
+import { ROW_HEIGHT, ROW_COUNT, HEADER_HEIGHT } from './constants/layout';
 import { getEndAt } from './utils/getEndAt';
 import { GRID_STEP_MS, } from './constants/time';
 import { getNextAvailableCastTime, roundToGridMs } from './utils/timeline';
@@ -166,6 +167,8 @@ export default function App() {
   interface Buff { id:number; key:string; start:number; end:number; label:string; group:number; src?:number; multiplier?: number; source?: string; }
   const [buffs, setBuffs] = useState<Buff[]>([]);
   const [nextBuffId, setNextBuffId] = useState(-1);
+
+  const containerHeight = ROW_HEIGHT * ROW_COUNT + HEADER_HEIGHT;
 
   const chi = useSelector((state: RootState) => state.chi.value);
   const dispatch: AppDispatch = useDispatch();
@@ -731,7 +734,7 @@ export default function App() {
         );
       })()}
       </aside>
-      <main className="timeline-container">
+      <main className="timeline-container" style={{ height: containerHeight }}>
         <Timeline
           items={[...hasteItems, ...items, ...buffItems, ...cdBars]}
           start={viewStart}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -114,7 +114,7 @@ export const Timeline = ({
       groupDS.current,
       {
         stack: false,
-        height: "400px",
+        height: "100%",
         align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,4 @@
+export { TIMELINE_ROW_ORDER } from './timelineRows';
+export const ROW_HEIGHT = 48; // px
+export const ROW_COUNT = TIMELINE_ROW_ORDER.length;
+export const HEADER_HEIGHT = 40; // px

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,8 @@ body.light {
 /* layout containers */
 .app-layout {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- remove fixed `100vh` height on `.app-layout`
- expose `ROW_HEIGHT`, `ROW_COUNT` and `HEADER_HEIGHT` constants
- size the timeline container using row height and count
- let the timeline widget fill its parent

## Testing
- `pnpm run test`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6885742a4554832fa873351796b2d086