### PR TITLE
Make timeline container auto resize

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { AbilityPalette } from './components/AbilityPalette';
 import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 import { getOriginalChiCost, getActualChiCost } from './utils/chiCost';
+import { ROW_HEIGHT, ROW_COUNT } from './constants/timelineLayout';
 
 interface CalcBuff {
   id: number;
@@ -627,6 +628,9 @@ export default function App() {
   const update = (field: string, value: number) =>
     setStats(s => ({ ...s, [field]: value }));
 
+  const HEADER_HEIGHT = 40;
+  const containerHeight = ROW_HEIGHT * ROW_COUNT + HEADER_HEIGHT;
+
   return (
     <div className="app-layout">
       <aside className="sidebar p-4 space-y-4">
@@ -731,7 +735,7 @@ export default function App() {
         );
       })()}
       </aside>
-      <main className="timeline-container">
+      <main className="timeline-container" style={{ height: containerHeight }}>
         <Timeline
           items={[...hasteItems, ...items, ...buffItems, ...cdBars]}
           start={viewStart}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -114,7 +114,7 @@ export const Timeline = ({
       groupDS.current,
       {
         stack: false,
-        height: "400px",
+        height: '100%',
         align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),

--- a/src/constants/timelineLayout.ts
+++ b/src/constants/timelineLayout.ts
@@ -1,0 +1,4 @@
+import { TIMELINE_ROW_ORDER } from './timelineRows';
+
+export const ROW_HEIGHT = 60;
+export const ROW_COUNT = TIMELINE_ROW_ORDER.length;

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,8 @@ body.light {
 /* layout containers */
 .app-layout {
   display: flex;
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   width: 100%;
 }
 
@@ -103,16 +104,17 @@ body.light {
 }
 
 .timeline-container {
-  flex: 1;
-  overflow: auto;
+  width: 75%;
+  overflow-y: auto;
 }
 
 /* larger timeline rows */
+
 .vis-item {
-  height: 48px;
-  line-height: 48px;
+  height: 60px;
+  line-height: 60px;
 }
 
 .vis-group {
-  height: 48px;
+  height: 60px;
 }


### PR DESCRIPTION
## Summary
- allow the main layout to expand by removing fixed height
- centralize timeline row layout constants
- compute container height dynamically and set the Timeline to fill it
- update CSS to size rows and container with new constant

## Testing
- `pnpm test`
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6885742a4554832fa873351796b2d086