### PR TITLE
Fix layout issues for expanding timeline and icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,7 +272,7 @@ export default function App() {
     }
     const icon = ABILITY_ICON_MAP[key];
     const label = icon
-      ? `<img src="${icon.src}" alt="${ability.name}" style="width:10px;height:10px"/>`
+      ? `<div class="timeline-event-icon"><img src="${icon.src}" alt="${ability.name}" /></div>`
       : ability.name;
     const group = groupMap[key];
     const id = nextId;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -114,7 +114,7 @@ export const Timeline = ({
       groupDS.current,
       {
         stack: false,
-        height: "400px",
+        height: `${groups.length * 48 + 50}px`,
         align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),

--- a/src/index.css
+++ b/src/index.css
@@ -93,18 +93,21 @@ body.light {
 /* layout containers */
 .app-layout {
   display: flex;
-  height: 100vh;
+  align-items: flex-start;
+  min-height: 100vh;
   width: 100%;
 }
 
 .sidebar {
   flex: 0 0 25%;
   overflow-y: auto;
+  max-height: 100vh;
 }
 
 .timeline-container {
   flex: 1;
-  overflow: auto;
+  overflow-y: auto;
+  max-height: 100vh;
 }
 
 /* larger timeline rows */
@@ -115,4 +118,14 @@ body.light {
 
 .vis-group {
   height: 48px;
+}
+
+.timeline-event-icon {
+  height: 100%;
+}
+
+.timeline-event-icon img {
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- allow layout to expand past viewport height
- keep sidebar and timeline capped at screen height
- keep skill icons sized inside timeline rows
- resize Vis timeline based on row count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857cf6e568832f9641f81f1dc4e3ba