### PR TITLE
Fix timeline growth and icon sizes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,7 +272,7 @@ export default function App() {
     }
     const icon = ABILITY_ICON_MAP[key];
     const label = icon
-      ? `<img src="${icon.src}" alt="${ability.name}" style="width:10px;height:10px"/>`
+      ? `<div class="timeline-event-icon"><img src="${icon.src}" alt="${ability.name}" /></div>`
       : ability.name;
     const group = groupMap[key];
     const id = nextId;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -108,13 +108,14 @@ export const Timeline = ({
 
   useEffect(() => {
     if (!containerRef.current || timelineRef.current) return;
+    const totalHeight = groups.length * 48 + 50;
     const tl = new VisTimeline(
       containerRef.current,
       itemDS.current,
       groupDS.current,
       {
         stack: false,
-        height: "400px",
+        height: totalHeight + "px",
         align: 'left',
         start: new Date(start * 1000),
         end: new Date(end * 1000),

--- a/src/index.css
+++ b/src/index.css
@@ -93,18 +93,21 @@ body.light {
 /* layout containers */
 .app-layout {
   display: flex;
-  height: 100vh;
+  align-items: flex-start;
+  min-height: 100vh;
   width: 100%;
 }
 
 .sidebar {
   flex: 0 0 25%;
   overflow-y: auto;
+  max-height: 100vh;
 }
 
 .timeline-container {
   flex: 1;
-  overflow: auto;
+  overflow-y: auto;
+  max-height: 100vh;
 }
 
 /* larger timeline rows */
@@ -115,4 +118,15 @@ body.light {
 
 .vis-group {
   height: 48px;
+}
+
+/* ensure timeline event icons fit within row */
+.timeline-event-icon {
+  height: 100%;
+}
+
+.timeline-event-icon img {
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
 }


### PR DESCRIPTION
## Summary
- let timeline panel grow and scroll when content exceeds the viewport
- compute vis timeline height from row count
- limit timeline item icon height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857cf6e568832f9641f81f1dc4e3ba