### PR TITLE
Unify GCD bars and highlight icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,8 +87,15 @@ function recomputeTimeline(
       key === 'FoF' ? ['AA_BD', 'SW_BD', 'CC_BD'] : [],
     );
     const dur = end - it.start;
+    const isGCD = ability.triggersGCD ?? true;
+    const duration = dur > 0 ? dur : isGCD ? 1 : 0;
     const idx = items.findIndex(x => x.id === it.id);
-    if (idx >= 0) items[idx] = { ...items[idx], end: dur > 0 ? it.start + dur : undefined };
+    if (idx >= 0)
+      items[idx] = {
+        ...items[idx],
+        end: duration > 0 ? it.start + duration : undefined,
+        type: duration > 0 ? 'guide' : undefined,
+      };
 
     const recs = casts[key] || [];
     const maxCharges = key === 'SEF' ? ability.charges ?? 2 : 1;
@@ -258,6 +265,8 @@ export default function App() {
       key === 'FoF' ? ['AA_BD', 'SW_BD', 'CC_BD'] : [],
     );
     const castDur = endTime - now;
+    const isGCD = ability.triggersGCD ?? true;
+    const duration = castDur > 0 ? castDur : isGCD ? 1 : 0;
     // existing cooldown records for this ability (keep history)
     const cds = casts[key] || [];
     const active = cds.filter(cd => getEndAt(cd, buffs) > now);
@@ -283,11 +292,11 @@ export default function App() {
         id,
         group,
         start: now,
-        end: castDur > 0 ? now + castDur : undefined,
+        end: duration > 0 ? now + duration : undefined,
         label,
         ability: key,
         pendingDelete: false,
-        type: castDur > 0 ? 'guide' : undefined,
+        type: duration > 0 ? 'guide' : undefined,
       },
     ]);
     const extraBuffs: Buff[] = [];
@@ -368,7 +377,7 @@ export default function App() {
       ];
       return out;
     });
-    setTime(now + (castDur > 0 ? castDur : key === 'SEF' ? 0.001 : 1));
+    setTime(now + (castDur > 0 ? castDur : isGCD ? 1 : 0.001));
   };
 
   // vertical lines showing when a cooldown finishes

--- a/src/constants/abilities.ts
+++ b/src/constants/abilities.ts
@@ -8,6 +8,8 @@ export interface Ability {
   snapshot?: boolean;
   baseChannelMs?: number;
   channelDynamic?: boolean;
+  /** Whether the ability triggers the global cooldown */
+  triggersGCD?: boolean;
   row?: TimelineRow;
 }
 
@@ -65,5 +67,5 @@ export const ABILITIES: Record<string, Ability> = {
 export function abilityById(id: string): Ability {
   const a = ABILITIES[id];
   if (!a) throw new Error(`unknown ability ${id}`);
-  return a;
+  return { ...a, triggersGCD: a.triggersGCD ?? true };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,18 @@ body.light {
   border-color: red;
 }
 
+.vis-item.warning .timeline-event-icon {
+  border: 2px solid orange;
+  border-radius: 4px;
+  box-shadow: 0 0 4px orange;
+}
+
+.vis-item.highlight .timeline-event-icon {
+  border: 2px solid red;
+  border-radius: 4px;
+  box-shadow: 0 0 6px red;
+}
+
 .vis-item.warning { border-color: orange; }
 /* ensure selected items keep the warning color */
 .vis-item.warning.vis-selected { border-color: orange; }

--- a/src/jobs/windwalker.ts
+++ b/src/jobs/windwalker.ts
@@ -23,8 +23,21 @@ const HASTED: WWKey[] = ['RSK', 'FoF', 'WU', 'SCK', 'SCK_HL'];
 
 export const wwData = (haste: number) =>
   Object.fromEntries(
-    Object.entries(WW).map(([k, id]) => [
-      k,
-      { ...getSpell(id, haste), affectedByHaste: HASTED.includes(k as WWKey) },
-    ])
-  ) as Record<WWKey, ReturnType<typeof getSpell> & { affectedByHaste: boolean }>;
+    Object.entries(WW).map(([k, id]) => {
+      const spell = getSpell(id, haste);
+      return [
+        k,
+        {
+          ...spell,
+          affectedByHaste: HASTED.includes(k as WWKey),
+          triggersGCD: spell.gcd !== 0,
+        },
+      ];
+    })
+  ) as Record<
+    WWKey,
+    ReturnType<typeof getSpell> & {
+      affectedByHaste: boolean;
+      triggersGCD: boolean;
+    }
+  >;


### PR DESCRIPTION
## Summary
- extend `Ability` with `triggersGCD` flag and default it to `true`
- expose the flag in `wwData`
- render instant abilities that trigger the GCD as 1s range bars
- outline ability icons when items have warning or highlight states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688583d90c00832f9dc5dd685c31f3af