### PR TITLE
feat: BOK refreshes FoF/RSK CDs

### DIFF
--- a/src/lib/cooldown.ts
+++ b/src/lib/cooldown.ts
@@ -30,3 +30,44 @@ export function cdEnd(
   }
   return t;
 }
+
+export function cdUnits(
+  start: number,
+  end: number,
+  buffs: Buff[],
+  speedAt: SpeedFn,
+) {
+  if (end <= start) return 0;
+  const points = Array.from(
+    new Set(
+      buffs
+        .flatMap(b => [b.start, b.end])
+        .filter(t => t > start && t < end),
+    ),
+  ).sort((a, b) => a - b);
+  points.push(end);
+  let t = start;
+  let acc = 0;
+  for (const p of points) {
+    const seg = Math.min(p, end);
+    const speed = speedAt(t, buffs);
+    acc += (seg - t) * speed;
+    t = seg;
+    if (t >= end) break;
+  }
+  return acc;
+}
+
+export function reduceCd<T extends { start: number; base: number }>(
+  cast: T,
+  time: number,
+  amount: number,
+  buffs: Buff[],
+  speedAt: SpeedFn,
+): T {
+  const end = cdEnd(cast.start, cast.base, buffs, speedAt);
+  if (end <= time || amount <= 0) return cast;
+  const newEnd = Math.max(time, end - amount);
+  const newBase = cdUnits(cast.start, newEnd, buffs, speedAt);
+  return { ...cast, base: newBase };
+}

--- a/tests/bok_refresh.spec.ts
+++ b/tests/bok_refresh.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { cdEnd, reduceCd } from '../src/lib/cooldown';
+import { cdSpeedAt } from '../src/lib/speed';
+
+const mk = (key: string, start: number, end: number) => ({ key, start, end } as any);
+
+function afterRefresh(buffs: any[], at: number, base=24) {
+  const cast = { id:'FoF', start:0, base };
+  const origEnd = cdEnd(cast.start, cast.base, buffs, cdSpeedAt);
+  const amt = cdSpeedAt(at, buffs);
+  const upd = reduceCd(cast, at, amt, buffs, cdSpeedAt);
+  const end = cdEnd(upd.start, upd.base, buffs, cdSpeedAt);
+  return { origEnd, end };
+}
+
+describe('BOK cooldown refresh', () => {
+  it('reduces by 1s without buffs', () => {
+    const { origEnd, end } = afterRefresh([], 2);
+    expect(origEnd).toBe(24);
+    expect(end).toBeCloseTo(23, 3);
+  });
+
+  it('scales with SW buff', () => {
+    const sw = mk('SW_BD',0,8);
+    const { end } = afterRefresh([sw], 2);
+    expect(end).toBeCloseTo(16.25, 2);
+  });
+
+  it('scales with SW+AA', () => {
+    const sw = mk('SW_BD',0,8);
+    const aa = mk('AA_BD',0,6);
+    const { end } = afterRefresh([sw,aa], 2);
+    expect(end).toBeCloseTo(7.0625, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add cooldown utilities `cdUnits` and `reduceCd`
- implement BOK and BLK_HL refreshing FoF/RSK cooldowns in timeline logic
- show tooltip of refresh amount
- unit tests for the refresh mechanic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68858e569970832fabb61d61daf7d92d