### PR TITLE
Implement new monk buffs and fix SEF GCD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { cdSpeedAt } from './lib/speed';
 import { cdUnits, reduceCd } from './lib/cooldown';
 import { fmt } from './util/fmt';
 import { computeBlessingSegments } from './util/blessingSegments';
+import { computeAcclamationSegments } from './util/acclamationSegments';
 import { SkillCast } from './types';
 import { AbilityIcon } from './components/AbilityIcon';
 import { AbilityPalette } from './components/AbilityPalette';
@@ -145,6 +146,10 @@ function recomputeTimeline(
       buffs.push({ id: --nid, key: 'BL', start: it.start, end: it.start + 40, label: 'Bloodlust', group: 2, src: it.id, multiplier: 1.3 });
     } else if (key === 'SEF') {
       buffs.push({ id: --nid, key: 'SEF', start: it.start, end: it.start + 15, label: 'SEF', group: 3, src: it.id });
+    } else if (key === 'RSK') {
+      buffs.push({ id: --nid, key: 'Acclamation', start: it.start, end: it.start + 12, label: 'Acclamation', group: 2, src: it.id });
+    } else if (key === 'Xuen') {
+      buffs.push({ id: --nid, key: 'XuenHaste', start: it.start, end: it.start + 20, label: 'Xuen', group: 1, src: it.id, multiplier: 1.15 });
     }
 
     const hasteMult = (ability as any).affectedByHaste
@@ -337,6 +342,12 @@ export default function App() {
     } else if (key === 'SEF') {
       extraBuffs.push({ id: nextBuffId, key: 'SEF', start: now, end: now + 15, label: 'SEF', group: 3, src: id } as any);
       setNextBuffId(nextBuffId - 1);
+    } else if (key === 'RSK') {
+      extraBuffs.push({ id: nextBuffId, key: 'Acclamation', start: now, end: now + 12, label: 'Acclamation', group: 2, src: id } as any);
+      setNextBuffId(nextBuffId - 1);
+    } else if (key === 'Xuen') {
+      extraBuffs.push({ id: nextBuffId, key: 'XuenHaste', start: now, end: now + 20, label: 'Xuen', group: 1, src: id, multiplier: 1.15 } as any);
+      setNextBuffId(nextBuffId - 1);
     }
 
     if (extraBuffs.length) {
@@ -439,7 +450,9 @@ export default function App() {
     : [];
 
   const qlBuffs = buffs.filter(b => b.key.endsWith('_BD'));
-  const otherBuffs = buffs.filter(b => !b.key.endsWith('_BD'));
+  const nonQlBuffs = buffs.filter(b => !b.key.endsWith('_BD'));
+  const acclamationBuffs = nonQlBuffs.filter(b => b.key === 'Acclamation');
+  const otherBuffs = nonQlBuffs.filter(b => b.key !== 'Acclamation');
 
   const blessingBuffs = React.useMemo(() => {
     const dragons = [...qlBuffs].sort((a, b) => a.start - b.start);
@@ -504,9 +517,22 @@ export default function App() {
     }));
   })();
 
+  const acclamationItems: TLItem[] = (() => {
+    const segs = computeAcclamationSegments(acclamationBuffs);
+    return segs.map((seg, i) => ({
+      id: 16000 + i,
+      group: 2,
+      start: seg.start,
+      end: seg.end,
+      label: `Acclamation ${seg.stacks * 3}%`,
+      className: 'buff',
+    }));
+  })();
+
   const buffItems: TLItem[] = [
     ...qlItems,
     ...blessingItems,
+    ...acclamationItems,
     ...otherBuffs.map(b => {
       const item: TLItem = {
         id: b.id,

--- a/src/data/monk_spells.json
+++ b/src/data/monk_spells.json
@@ -246,7 +246,7 @@
     "effects": [
       {}
     ],
-    "gcd": 1,
+    "gcd": 0,
     "cooldown": 90,
     "charges": 2
   },

--- a/src/util/acclamationSegments.ts
+++ b/src/util/acclamationSegments.ts
@@ -1,0 +1,23 @@
+export interface AcclamationBuff {
+  start: number;
+  end: number;
+}
+
+export interface AcclamationSegment {
+  start: number;
+  end: number;
+  stacks: number;
+}
+
+export function computeAcclamationSegments(buffs: AcclamationBuff[]): AcclamationSegment[] {
+  const times = Array.from(new Set(buffs.flatMap(b => [b.start, b.end]))).sort((a, b) => a - b);
+  const segs: AcclamationSegment[] = [];
+  for (let i = 0; i < times.length - 1; i++) {
+    const s = times[i];
+    const e = times[i + 1];
+    const mid = (s + e) / 2;
+    const stacks = buffs.filter(b => b.start <= mid && mid < b.end).length;
+    if (stacks > 0) segs.push({ start: s, end: e, stacks });
+  }
+  return segs;
+}

--- a/tests/acclamation.spec.ts
+++ b/tests/acclamation.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { computeAcclamationSegments } from '../src/util/acclamationSegments';
+
+describe('Acclamation segments', () => {
+  it('merges overlapping debuffs', () => {
+    const buffs = [
+      { start: 0, end: 12 },
+      { start: 5, end: 17 },
+    ];
+    const segs = computeAcclamationSegments(buffs);
+    expect(segs.length).toBe(3);
+    expect(segs[0].stacks).toBe(1);
+    expect(segs[1].stacks).toBe(2);
+    expect(segs[2].stacks).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add Acclamation buff stacking logic and UI segments
- show Invoker's Delight as Xuen haste buff
- allow RSK and Xuen to create buffs in the planner
- treat SEF as off-GCD
- add basic unit test for Acclamation stacking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a020ff08832f8aa37793da6f6d6e