### PR TITLE
Fix SEF GCD and buff timeline colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,13 +90,23 @@ function recomputeTimeline(
     const dur = end - it.start;
     const isGCD = ability.triggersGCD ?? true;
     const duration = dur > 0 ? dur : isGCD ? 1 : 0;
+    const gcdOnly = isGCD && dur <= 0;
     const idx = items.findIndex(x => x.id === it.id);
-    if (idx >= 0)
+    if (idx >= 0) {
+      const cls = [
+        items[idx].className?.replace('gcd', '').trim(),
+        gcdOnly ? 'gcd' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
       items[idx] = {
         ...items[idx],
         end: duration > 0 ? it.start + duration : undefined,
         type: duration > 0 ? 'guide' : undefined,
+        className: cls,
+        gcdOnly,
       };
+    }
 
     const recs = casts[key] || [];
     const maxCharges = key === 'SEF' ? ability.charges ?? 2 : 1;
@@ -122,21 +132,21 @@ function recomputeTimeline(
     if (sefActiveBuff && origCost > 0) sefActiveBuff.end += 0.25 * origCost;
 
     if (key === 'AA') {
-      buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 7, src: it.id });
     } else if (key === 'SW') {
-      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 8, label: t('SW青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 8, label: t('SW青龙'), group: 7, src: it.id });
     } else if (key === 'CC') {
       const start = it.start + dur;
       buffs = buffs.map(b => (b.key === 'AA_BD' && b.start <= start && start < b.end ? { ...b, end: start } : b));
-      buffs.push({ id: --nid, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), group: 7, src: it.id });
     } else if (key === 'BL') {
-      buffs.push({ id: --nid, key: 'BL', start: it.start, end: it.start + 40, label: 'Bloodlust', group: 2, src: it.id, multiplier: 1.3 });
+      buffs.push({ id: --nid, key: 'BL', start: it.start, end: it.start + 40, label: 'Bloodlust', group: 5, src: it.id, multiplier: 1.3 });
     } else if (key === 'SEF') {
       buffs.push({ id: --nid, key: 'SEF', start: it.start, end: it.start + 15, label: 'SEF', group: 3, src: it.id });
     } else if (key === 'RSK') {
-      buffs.push({ id: --nid, key: 'Acclamation', start: it.start, end: it.start + 12, label: 'Acclamation', group: 2, src: it.id });
+      buffs.push({ id: --nid, key: 'Acclamation', start: it.start, end: it.start + 12, label: 'Acclamation', group: 4, src: it.id });
     } else if (key === 'Xuen') {
-      buffs.push({ id: --nid, key: 'Xuen', start: it.start, end: it.start + 20, label: 'Xuen', group: 1, src: it.id, multiplier: 1.15 });
+      buffs.push({ id: --nid, key: 'Xuen', start: it.start, end: it.start + 20, label: 'Xuen', group: 2, src: it.id, multiplier: 1.15 });
     }
 
     const hasteMult = (ability as any).affectedByHaste
@@ -221,20 +231,20 @@ export default function App() {
 
   // mapping from ability key to timeline group
   const groupMap: Record<WWKey, number> = {
-    Xuen: 6,
-    SEF: 6,
-    CC: 6,
-    AA: 7,
-    SW: 7,
-    FoF: 8,
-    RSK: 8,
-    WU: 8,
-    TP: 9,
-    BOK: 9,
-    SCK: 9,
-    SCK_HL: 9,
-    BLK_HL: 9,
-    BL: 2,
+    Xuen: 8,
+    SEF: 8,
+    CC: 8,
+    AA: 9,
+    SW: 9,
+    FoF: 10,
+    RSK: 10,
+    WU: 10,
+    TP: 11,
+    BOK: 11,
+    SCK: 11,
+    SCK_HL: 11,
+    BLK_HL: 11,
+    BL: 8,
   };
 
   // handler when an ability button is clicked
@@ -272,6 +282,7 @@ export default function App() {
     const castDur = endTime - now;
     const isGCD = ability.triggersGCD ?? true;
     const duration = castDur > 0 ? castDur : isGCD ? 1 : 0;
+    const gcdOnly = isGCD && castDur <= 0;
     // existing cooldown records for this ability (keep history)
     const cds = casts[key] || [];
     const active = cds.filter(cd => getEndAt(cd, buffs) > now);
@@ -302,14 +313,16 @@ export default function App() {
         ability: key,
         pendingDelete: false,
         type: duration > 0 ? 'guide' : undefined,
+        className: gcdOnly ? 'gcd' : undefined,
+        gcdOnly,
       },
     ]);
     const extraBuffs: Buff[] = [];
     if (key === 'AA') {
-      extraBuffs.push({ id: nextBuffId, key: 'AA_BD', start: now, end: now + 6, label: t('AA青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'AA_BD', start: now, end: now + 6, label: t('AA青龙'), src: id, group: 7 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'SW') {
-      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: now + castDur, end: now + castDur + 8, label: t('SW青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: now + castDur, end: now + castDur + 8, label: t('SW青龙'), src: id, group: 7 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'CC') {
       const start = now + castDur;
@@ -319,19 +332,19 @@ export default function App() {
           ? { ...b, end: start }
           : b
       ));
-      extraBuffs.push({ id: nextBuffId, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), src: id, group: 7 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'BL') {
-      extraBuffs.push({ id: nextBuffId, key: 'BL', start: now, end: now + 40, label: 'Bloodlust', group: 2, src: id, multiplier: 1.3 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'BL', start: now, end: now + 40, label: 'Bloodlust', group: 5, src: id, multiplier: 1.3 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'SEF') {
       extraBuffs.push({ id: nextBuffId, key: 'SEF', start: now, end: now + 15, label: 'SEF', group: 3, src: id } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'RSK') {
-      extraBuffs.push({ id: nextBuffId, key: 'Acclamation', start: now, end: now + 12, label: 'Acclamation', group: 2, src: id } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'Acclamation', start: now, end: now + 12, label: 'Acclamation', group: 4, src: id } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'Xuen') {
-      extraBuffs.push({ id: nextBuffId, key: 'Xuen', start: now, end: now + 20, label: 'Xuen', group: 1, src: id, multiplier: 1.15 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'Xuen', start: now, end: now + 20, label: 'Xuen', group: 2, src: id, multiplier: 1.15 } as any);
       setNextBuffId(nextBuffId - 1);
     }
 
@@ -469,10 +482,10 @@ export default function App() {
       if (extra > 0) {
         res.push({
           id: 10000 + i,
-          group: 5,
+          group: 7,
           start: s,
           end: e,
-          label: `${t('青龙')}+${extra.toFixed(2)}cd/s`,
+          label: `+${extra.toFixed(2)}s/s`,
           className: 'buff',
         });
       }
@@ -484,7 +497,7 @@ export default function App() {
     const segs = computeBlessingSegments(blessingBuffs);
     return segs.map((seg, i) => ({
       id: 15000 + i,
-      group: 4,
+      group: 6,
       start: seg.start,
       end: seg.end,
       label: `${seg.stacks}×`,
@@ -497,10 +510,10 @@ export default function App() {
     const segs = computeAcclamationSegments(acclamationBuffs);
     return segs.map((seg, i) => ({
       id: 15500 + i,
-      group: 2,
+      group: 4,
       start: seg.start,
       end: seg.end,
-      label: `Acclamation ${seg.pct}%`,
+      label: `${seg.pct}%`,
       className: 'buff',
     }));
   })();

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -7,7 +7,7 @@ import { GRID_STEP_MS } from "../constants/time";
 // bars (used for cooldown visualization).
 export interface TLItem {
   id: number;
-  group: number; // group id 1-7
+  group: number; // timeline group id
   start: number; // start time in seconds
   end?: number; // optional end time in seconds
   label: string;
@@ -16,6 +16,7 @@ export interface TLItem {
   className?: string;
   pendingDelete?: boolean;
   type?: string;
+  gcdOnly?: boolean;
   title?: string;
 }
 
@@ -24,8 +25,10 @@ import { GUIDE_COLOR } from '../constants/colors';
 
 const groups = [
   'Haste',
-  'Buffs',
-  t('Boss技能'),
+  'Xuen',
+  'SEF',
+  'Acclamation',
+  'Bloodlust',
   'Blessing',
   t('青龙之心'),
   'Major Cooldown',
@@ -197,7 +200,12 @@ export const Timeline = ({
         className: [it.className, it.type === 'guide' ? 'event-guide' : ''].filter(Boolean).join(' '),
         ...(it.stacks ? { stacks: it.stacks } : {}),
         ...(it.title ? { title: it.title } : {}),
-        style: it.type === 'guide' ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#fff` : undefined,
+        style:
+          it.type === 'guide'
+            ? it.gcdOnly
+              ? undefined
+              : `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#000`
+            : undefined,
       })),
     );
   }, [items]);

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,1 +1,1 @@
-export const GUIDE_COLOR = '#003377';
+export const GUIDE_COLOR = '#66B2FF';

--- a/src/index.css
+++ b/src/index.css
@@ -21,27 +21,31 @@ body.light {
 }
 
 .vis-item.highlight {
-  background-color: rgba(255, 0, 0, 0.4);
-  border-color: red;
+  background-color: rgba(255, 0, 0, 0.2);
+  border-color: #ff6666;
 }
 
 .vis-item.warning .timeline-event-icon {
-  border: 2px solid orange;
+  border: 2px solid #ffcc99;
   border-radius: 4px;
-  box-shadow: 0 0 4px orange;
+  box-shadow: 0 0 4px #ffcc99;
 }
 
 .vis-item.highlight .timeline-event-icon {
-  border: 2px solid red;
+  border: 2px solid #ff6666;
   border-radius: 4px;
-  box-shadow: 0 0 6px red;
+  box-shadow: 0 0 6px #ff6666;
 }
 
-.vis-item.warning { border-color: orange; }
+.vis-item.warning { border-color: #ffcc99; }
 /* ensure selected items keep the warning color */
-.vis-item.warning.vis-selected { border-color: orange; }
+.vis-item.warning.vis-selected { border-color: #ffcc99; }
 
 .vis-item.buff {
+  background-color: rgba(0, 255, 0, 0.2);
+  border-color: rgba(0, 128, 0, 0.5);
+}
+.vis-item.gcd {
   background-color: rgba(0, 255, 0, 0.2);
   border-color: rgba(0, 128, 0, 0.5);
 }
@@ -51,15 +55,15 @@ body.light {
 }
 
 .vis-item.haste {
-  background-color: #001C55;
-  border-color: #001C55;
+  background-color: #003377;
+  border-color: #003377;
   color: #fff;
 }
 
 .vis-item.blessing {
-  background-color: #004400;
-  border-color: #004400;
-  color: #fff;
+  background-color: rgba(0, 255, 0, 0.2);
+  border-color: rgba(0, 128, 0, 0.5);
+  color: #000;
 }
 .vis-item.blessing .vis-item-content {
   font-size: 11px;
@@ -70,9 +74,9 @@ body.light {
 }
 
 .vis-item.event-guide {
-  background-color: #003377;
-  border-color: #003377;
-  color: #fff;
+  background-color: #66B2FF;
+  border-color: #66B2FF;
+  color: #000;
 }
 .vis-item.event-guide .vis-item-content {
   padding: 0;

--- a/src/lib/spell-db.ts
+++ b/src/lib/spell-db.ts
@@ -26,7 +26,8 @@ export const getSpell = (id: number, rating = 0) => {
     throw new Error(`❌ Spell id ${id} not found in monk_spells.json`);
   }
   const haste = ratingToHaste(rating);
-  const gcd = 1; // 踏风固定 1s GCD
+  const baseGCD = s.gcd ?? 1;
+  const gcd = baseGCD === 0 ? 0 : 1; // respect 0 for abilities that ignore GCD
   const castEff = effTime(s.cast ?? 0, haste, 0);
   return { ...s, gcd, castEff };
 };


### PR DESCRIPTION
## Summary
- respect gcd=0 in spell data
- add dedicated timeline rows for major buffs
- use light blue cast bars and green pseudo-cast bars
- lighten warning and delete highlights
- give Blessing buff a light-green style and tweak haste color
- shorten Acclamation and 青龙之心 labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b5e1ffd4832fb5d2af2814edac49