### PR TITLE
Fix SEF GCD and separate buff rows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function computeBlessingBuffs(dragons: CalcBuff[]): CalcBuff[] {
       start,
       end,
       label: t('祝福'),
-      group: 4,
+      group: 7,
       multiplier: 1.15,
       source,
     });
@@ -122,21 +122,21 @@ function recomputeTimeline(
     if (sefActiveBuff && origCost > 0) sefActiveBuff.end += 0.25 * origCost;
 
     if (key === 'AA') {
-      buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 8, src: it.id });
     } else if (key === 'SW') {
-      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 8, label: t('SW青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 8, label: t('SW青龙'), group: 8, src: it.id });
     } else if (key === 'CC') {
       const start = it.start + dur;
       buffs = buffs.map(b => (b.key === 'AA_BD' && b.start <= start && start < b.end ? { ...b, end: start } : b));
-      buffs.push({ id: --nid, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), group: 5, src: it.id });
+      buffs.push({ id: --nid, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), group: 8, src: it.id });
     } else if (key === 'BL') {
-      buffs.push({ id: --nid, key: 'BL', start: it.start, end: it.start + 40, label: 'Bloodlust', group: 2, src: it.id, multiplier: 1.3 });
+      buffs.push({ id: --nid, key: 'BL', start: it.start, end: it.start + 40, label: 'Bloodlust', group: 5, src: it.id, multiplier: 1.3 });
     } else if (key === 'SEF') {
       buffs.push({ id: --nid, key: 'SEF', start: it.start, end: it.start + 15, label: 'SEF', group: 3, src: it.id });
     } else if (key === 'RSK') {
-      buffs.push({ id: --nid, key: 'Acclamation', start: it.start, end: it.start + 12, label: 'Acclamation', group: 2, src: it.id });
+      buffs.push({ id: --nid, key: 'Acclamation', start: it.start, end: it.start + 12, label: 'Acclamation', group: 4, src: it.id });
     } else if (key === 'Xuen') {
-      buffs.push({ id: --nid, key: 'Xuen', start: it.start, end: it.start + 20, label: 'Xuen', group: 1, src: it.id, multiplier: 1.15 });
+      buffs.push({ id: --nid, key: 'Xuen', start: it.start, end: it.start + 20, label: 'Xuen', group: 2, src: it.id, multiplier: 1.15 });
     }
 
     const hasteMult = (ability as any).affectedByHaste
@@ -221,20 +221,20 @@ export default function App() {
 
   // mapping from ability key to timeline group
   const groupMap: Record<WWKey, number> = {
-    Xuen: 6,
-    SEF: 6,
-    CC: 6,
-    AA: 7,
-    SW: 7,
-    FoF: 8,
-    RSK: 8,
-    WU: 8,
-    TP: 9,
-    BOK: 9,
-    SCK: 9,
-    SCK_HL: 9,
-    BLK_HL: 9,
-    BL: 2,
+    Xuen: 9,
+    SEF: 9,
+    CC: 9,
+    AA: 10,
+    SW: 10,
+    FoF: 11,
+    RSK: 11,
+    WU: 11,
+    TP: 12,
+    BOK: 12,
+    SCK: 12,
+    SCK_HL: 12,
+    BLK_HL: 12,
+    BL: 5,
   };
 
   // handler when an ability button is clicked
@@ -272,6 +272,7 @@ export default function App() {
     const castDur = endTime - now;
     const isGCD = ability.triggersGCD ?? true;
     const duration = castDur > 0 ? castDur : isGCD ? 1 : 0;
+    const itemType = castDur > 0 ? 'guide' : isGCD ? 'gcd' : undefined;
     // existing cooldown records for this ability (keep history)
     const cds = casts[key] || [];
     const active = cds.filter(cd => getEndAt(cd, buffs) > now);
@@ -301,15 +302,15 @@ export default function App() {
         label,
         ability: key,
         pendingDelete: false,
-        type: duration > 0 ? 'guide' : undefined,
+        type: itemType,
       },
     ]);
     const extraBuffs: Buff[] = [];
     if (key === 'AA') {
-      extraBuffs.push({ id: nextBuffId, key: 'AA_BD', start: now, end: now + 6, label: t('AA青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'AA_BD', start: now, end: now + 6, label: t('AA青龙'), src: id, group: 8 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'SW') {
-      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: now + castDur, end: now + castDur + 8, label: t('SW青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: now + castDur, end: now + castDur + 8, label: t('SW青龙'), src: id, group: 8 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'CC') {
       const start = now + castDur;
@@ -319,19 +320,19 @@ export default function App() {
           ? { ...b, end: start }
           : b
       ));
-      extraBuffs.push({ id: nextBuffId, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), src: id, group: 5 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'CC_BD', start, end: start + 6, label: t('CC青龙'), src: id, group: 8 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'BL') {
-      extraBuffs.push({ id: nextBuffId, key: 'BL', start: now, end: now + 40, label: 'Bloodlust', group: 2, src: id, multiplier: 1.3 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'BL', start: now, end: now + 40, label: 'Bloodlust', group: 5, src: id, multiplier: 1.3 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'SEF') {
       extraBuffs.push({ id: nextBuffId, key: 'SEF', start: now, end: now + 15, label: 'SEF', group: 3, src: id } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'RSK') {
-      extraBuffs.push({ id: nextBuffId, key: 'Acclamation', start: now, end: now + 12, label: 'Acclamation', group: 2, src: id } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'Acclamation', start: now, end: now + 12, label: 'Acclamation', group: 4, src: id } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'Xuen') {
-      extraBuffs.push({ id: nextBuffId, key: 'Xuen', start: now, end: now + 20, label: 'Xuen', group: 1, src: id, multiplier: 1.15 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'Xuen', start: now, end: now + 20, label: 'Xuen', group: 2, src: id, multiplier: 1.15 } as any);
       setNextBuffId(nextBuffId - 1);
     }
 
@@ -441,7 +442,7 @@ export default function App() {
         start,
         end,
         label: t('祝福'),
-        group: 4,
+        group: 7,
         multiplier: 1.15,
         source,
       } as Buff);
@@ -469,10 +470,10 @@ export default function App() {
       if (extra > 0) {
         res.push({
           id: 10000 + i,
-          group: 5,
+          group: 8,
           start: s,
           end: e,
-          label: `${t('青龙')}+${extra.toFixed(2)}cd/s`,
+          label: `+${extra.toFixed(2)}s/s`,
           className: 'buff',
         });
       }
@@ -484,7 +485,7 @@ export default function App() {
     const segs = computeBlessingSegments(blessingBuffs);
     return segs.map((seg, i) => ({
       id: 15000 + i,
-      group: 4,
+      group: 7,
       start: seg.start,
       end: seg.end,
       label: `${seg.stacks}×`,
@@ -497,10 +498,10 @@ export default function App() {
     const segs = computeAcclamationSegments(acclamationBuffs);
     return segs.map((seg, i) => ({
       id: 15500 + i,
-      group: 2,
+      group: 4,
       start: seg.start,
       end: seg.end,
-      label: `Acclamation ${seg.pct}%`,
+      label: `${seg.pct}%`,
       className: 'buff',
     }));
   })();

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -24,7 +24,10 @@ import { GUIDE_COLOR } from '../constants/colors';
 
 const groups = [
   'Haste',
-  'Buffs',
+  'Xuen',
+  'SEF',
+  'Acclamation',
+  'Bloodlust',
   t('Boss技能'),
   'Blessing',
   t('青龙之心'),
@@ -194,10 +197,19 @@ export const Timeline = ({
         start: new Date(it.start * 1000),
         end: it.end ? new Date(it.end * 1000) : undefined,
         type: it.end ? "range" : "box",
-        className: [it.className, it.type === 'guide' ? 'event-guide' : ''].filter(Boolean).join(' '),
+        className: [
+          it.className,
+          it.type === 'guide' ? 'event-guide' : '',
+          it.type === 'gcd' ? 'gcd' : '',
+        ]
+          .filter(Boolean)
+          .join(' '),
         ...(it.stacks ? { stacks: it.stacks } : {}),
         ...(it.title ? { title: it.title } : {}),
-        style: it.type === 'guide' ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#fff` : undefined,
+        style:
+          it.type === 'guide'
+            ? `background-color:${GUIDE_COLOR};border-color:${GUIDE_COLOR};color:#000`
+            : undefined,
       })),
     );
   }, [items]);

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,1 +1,1 @@
-export const GUIDE_COLOR = '#003377';
+export const GUIDE_COLOR = '#66B2FF';

--- a/src/index.css
+++ b/src/index.css
@@ -21,14 +21,14 @@ body.light {
 }
 
 .vis-item.highlight {
-  background-color: rgba(255, 0, 0, 0.4);
-  border-color: red;
+  background-color: rgba(255, 0, 0, 0.2);
+  border-color: #ff6666;
 }
 
 .vis-item.warning .timeline-event-icon {
-  border: 2px solid orange;
+  border: 2px solid #ffcc99;
   border-radius: 4px;
-  box-shadow: 0 0 4px orange;
+  box-shadow: 0 0 4px #ffcc99;
 }
 
 .vis-item.highlight .timeline-event-icon {
@@ -37,11 +37,18 @@ body.light {
   box-shadow: 0 0 6px red;
 }
 
-.vis-item.warning { border-color: orange; }
+.vis-item.warning {
+  border-color: #ffcc99;
+  background-color: rgba(255, 204, 153, 0.2);
+}
 /* ensure selected items keep the warning color */
-.vis-item.warning.vis-selected { border-color: orange; }
+.vis-item.warning.vis-selected { border-color: #ffcc99; }
 
 .vis-item.buff {
+  background-color: rgba(0, 255, 0, 0.2);
+  border-color: rgba(0, 128, 0, 0.5);
+}
+.vis-item.gcd {
   background-color: rgba(0, 255, 0, 0.2);
   border-color: rgba(0, 128, 0, 0.5);
 }
@@ -51,15 +58,15 @@ body.light {
 }
 
 .vis-item.haste {
-  background-color: #001C55;
-  border-color: #001C55;
+  background-color: #003377;
+  border-color: #003377;
   color: #fff;
 }
 
 .vis-item.blessing {
-  background-color: #004400;
-  border-color: #004400;
-  color: #fff;
+  background-color: rgba(0, 255, 0, 0.2);
+  border-color: rgba(0, 128, 0, 0.5);
+  color: #000;
 }
 .vis-item.blessing .vis-item-content {
   font-size: 11px;
@@ -70,9 +77,9 @@ body.light {
 }
 
 .vis-item.event-guide {
-  background-color: #003377;
-  border-color: #003377;
-  color: #fff;
+  background-color: #66B2FF;
+  border-color: #66B2FF;
+  color: #000;
 }
 .vis-item.event-guide .vis-item-content {
   padding: 0;

--- a/src/lib/spell-db.ts
+++ b/src/lib/spell-db.ts
@@ -26,7 +26,8 @@ export const getSpell = (id: number, rating = 0) => {
     throw new Error(`❌ Spell id ${id} not found in monk_spells.json`);
   }
   const haste = ratingToHaste(rating);
-  const gcd = 1; // 踏风固定 1s GCD
+  const baseGCD = s.gcd ?? 1;
+  const gcd = baseGCD === 0 ? 0 : 1; // respect non-GCD abilities
   const castEff = effTime(s.cast ?? 0, haste, 0);
   return { ...s, gcd, castEff };
 };


### PR DESCRIPTION
## Summary
- respect `gcd: 0` in spell DB so SEF does not trigger GCD
- add separate timeline rows for Xuen, SEF, Acclamation and Bloodlust
- shorten labels for Acclamation and Yolo's Heart buffs
- color tweaks for casts, GCD bars, warnings and blessings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b5e1ffd4832fb5d2af2814edac49