### PR TITLE
Fix duplicate buff ids after timeline recompute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -562,6 +562,8 @@ export default function App() {
     setBuffs(newBuffs as any);
     setCasts(newCasts);
     dispatch(setChi(newChi));
+    const minBuffId = newBuffs.reduce((m, b) => Math.min(m, b.id), 0);
+    setNextBuffId(n => Math.min(n, minBuffId - 1));
   }, [items, stats.haste]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep negative buff id counter in sync with recomputed timeline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885beb6c300832f9e93ab93188d144d