### PR TITLE
Add SimulationCraft APL export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { AbilityPalette } from './components/AbilityPalette';
 import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 import { getOriginalChiCost, getActualChiCost } from './utils/chiCost';
+import { exportSimcApl } from './utils/simcApl';
 
 interface CalcBuff {
   id: number;
@@ -735,6 +736,17 @@ export default function App() {
   const update = (field: string, value: number) =>
     setStats(s => ({ ...s, [field]: value }));
 
+  const exportAPL = () => {
+    const abilityItems = items.filter(i => i.ability) as TLItem[];
+    const apl = exportSimcApl(
+      abilityItems.map(it => ({ ability: it.ability!, start: it.start })),
+      abilities,
+    );
+    navigator.clipboard.writeText(apl).then(() => {
+      alert(t('导出SimC APL'));
+    });
+  };
+
   return (
     <div className="app-layout">
       <aside className="sidebar p-4 space-y-4">
@@ -817,6 +829,7 @@ export default function App() {
           </select>
           <button onClick={loadPreset} className="px-2 py-1 border rounded">Load</button>
           <button onClick={deletePreset} className="px-2 py-1 border rounded">Delete</button>
+          <button onClick={exportAPL} className="px-2 py-1 border rounded">{t('导出SimC APL')}</button>
         </div>
       </div>
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -20,6 +20,7 @@ export const zhToEn: Record<string, string> = {
   'CC青龙': 'CC Yolo',
   'cd没转好': 'CD not ready',
   '引导中不能施放其他技能': 'Cannot cast while channeling',
+  '导出SimC APL': 'Export SimC APL',
 };
 
 export function t(zh: string): string {

--- a/src/utils/simcApl.ts
+++ b/src/utils/simcApl.ts
@@ -1,0 +1,34 @@
+export function toSimcName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]/g, '')
+    .trim()
+    .replace(/\s+/g, '_');
+}
+
+export interface AplItem {
+  ability: string;
+  start: number;
+}
+
+export function exportSimcApl(
+  items: AplItem[],
+  nameMap: Record<string, { name?: string }>,
+): string {
+  const sorted = [...items].sort((a, b) => a.start - b.start);
+  let out = '';
+  let prev = 0;
+  sorted.forEach((it, idx) => {
+    const entryName = nameMap[it.ability]?.name || it.ability;
+    const simc = toSimcName(entryName);
+    if (idx === 0) {
+      out += `actions+=/${simc}\n`;
+    } else {
+      const diff = Number((it.start - prev).toFixed(3));
+      if (diff > 0) out += `actions+=/wait,sec=${diff}\n`;
+      out += `actions+=/${simc}\n`;
+    }
+    prev = it.start;
+  });
+  return out.trim();
+}

--- a/tests/export_apl.spec.ts
+++ b/tests/export_apl.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { exportSimcApl } from '../src/utils/simcApl';
+import { wwData } from '../src/jobs/windwalker';
+
+(describe)("exportSimcApl", () => {
+  it('converts timeline to APL with waits', () => {
+    const abilities = wwData(0);
+    const items = [
+      { ability: 'TP', start: 0, id: 1, group: 1, label: '' },
+      { ability: 'RSK', start: 1.2, id: 2, group: 1, label: '' },
+      { ability: 'FoF', start: 1.9, id: 3, group: 1, label: '' },
+    ];
+    const apl = exportSimcApl(items, abilities);
+    expect(apl).toBe(
+`actions+=/tiger_palm
+actions+=/wait,sec=1.2
+actions+=/rising_sun_kick
+actions+=/wait,sec=0.7
+actions+=/fists_of_fury`);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `exportSimcApl` utility and APL name conversion
- add UI button to export timeline as SimC custom APL
- extend i18n dictionary
- test APL generation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688725dbd408832f952e955ad273deac