### PR TITLE
Add SimC APL export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { ABILITY_ICON_MAP } from './constants/icons';
 import { t } from './i18n/en';
 import { getOriginalChiCost, getActualChiCost } from './utils/chiCost';
 import { exportSimcApl } from './utils/simcApl';
+import { downloadText } from './utils/download';
 
 interface CalcBuff {
   id: number;
@@ -738,13 +739,17 @@ export default function App() {
 
   const exportAPL = () => {
     const abilityItems = items.filter(i => i.ability) as TLItem[];
-    const apl = exportSimcApl(
-      abilityItems.map(it => ({ ability: it.ability!, start: it.start })),
-      abilities,
-    );
-    navigator.clipboard.writeText(apl).then(() => {
-      alert(t('导出SimC APL'));
-    });
+    let apl: string;
+    try {
+      apl = exportSimcApl(
+        abilityItems.map(it => ({ ability: it.ability!, start: it.start })),
+        abilities,
+      );
+    } catch (e) {
+      alert((e as Error).message);
+      return;
+    }
+    downloadText(apl, 'shellwalker_export.simc');
   };
 
   return (

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,11 @@
+export function downloadText(text: string, filename: string) {
+  const blob = new Blob([text], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/utils/simcApl.ts
+++ b/src/utils/simcApl.ts
@@ -11,6 +11,24 @@ export interface AplItem {
   start: number;
 }
 
+const SIMC_NAME_MAP: Record<string, string> = {
+  TP: 'tiger_palm',
+  FoF: 'fists_of_fury',
+  RSK: 'rising_sun_kick',
+  RSK_HL: 'rising_sun_kick',
+  BLK: 'blackout_kick',
+  BOK: 'blackout_kick',
+  BLK_HL: 'blackout_kick',
+  WU: 'whirling_dragon_punch',
+  AA: 'strike_of_the_windlord',
+  SW: 'slicing_winds',
+  SEF: 'storm_earth_and_fire',
+  Xuen: 'invoke_xuen_the_white_tiger',
+  CC: 'celestial_conduit',
+  SCK: 'spinning_crane_kick',
+  SCK_HL: 'spinning_crane_kick',
+};
+
 export function exportSimcApl(
   items: AplItem[],
   nameMap: Record<string, { name?: string }>,
@@ -19,8 +37,14 @@ export function exportSimcApl(
   let out = '';
   let prev = 0;
   sorted.forEach((it, idx) => {
-    const entryName = nameMap[it.ability]?.name || it.ability;
-    const simc = toSimcName(entryName);
+    let simc = SIMC_NAME_MAP[it.ability];
+    if (!simc) {
+      const entryName = nameMap[it.ability]?.name;
+      if (!entryName) {
+        throw new Error(`Unsupported ability ${it.ability}`);
+      }
+      simc = toSimcName(entryName);
+    }
     if (idx === 0) {
       out += `actions+=/${simc}\n`;
     } else {


### PR DESCRIPTION
## Summary
- map internal ability codes to SimulationCraft names
- export timeline as SimC APL text file instead of copying to clipboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68872ce8e0cc832fafe0fd3919763126