### PR TITLE
Auto adjust skill time when overlapping channels

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -20,6 +20,8 @@ export const zhToEn: Record<string, string> = {
   'CC青龙': 'CC Yolo',
   'cd没转好': 'CD not ready',
   '引导中不能施放其他技能': 'Cannot cast while channeling',
+  '释放时间已自动调整至可用时间':
+    'Cast time has been auto-adjusted to the next available time',
   '导出SimC APL': 'Export SimC APL',
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -149,3 +149,15 @@ body.light {
   object-fit: contain;
   display: block;
 }
+
+.auto-adjust-toast {
+  position: absolute;
+  top: -1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 0, 0, 0.8);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- avoid overlapping skills by shifting start times
- notify user when cast time auto-adjusts
- add translation and styling for new notice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888fd8d0654832fb67f72d33b95b215