### PR TITLE
Implement automatic cast time adjustment

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -20,6 +20,7 @@ export const zhToEn: Record<string, string> = {
   'CC青龙': 'CC Yolo',
   'cd没转好': 'CD not ready',
   '引导中不能施放其他技能': 'Cannot cast while channeling',
+  '释放时间已自动调整至可用时间': 'Cast time has been auto-adjusted to the next available time',
   '导出SimC APL': 'Export SimC APL',
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -127,6 +127,7 @@ body.light {
   flex: 1;
   overflow-y: auto;
   max-height: 100vh;
+  position: relative;
 }
 
 /* larger timeline rows */
@@ -148,4 +149,18 @@ body.light {
   max-height: 100%;
   object-fit: contain;
   display: block;
+}
+
+.auto-adjust-toast {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #ff6666;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  z-index: 100;
+  pointer-events: none;
+  font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- avoid overlapping casts by shifting new ability start time
- show a short toast when start time auto-adjusts
- support dragging skills with the same logic
- tweak timeline CSS for toast display
- add translation for new toast message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888fd8d0654832fb67f72d33b95b215