### PR TITLE
Implement compact view mode

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -22,6 +22,8 @@ export const zhToEn: Record<string, string> = {
   '引导中不能施放其他技能': 'Cannot cast while channeling',
   '释放时间已自动调整至可用时间': 'Cast time has been auto-adjusted to the next available time',
   '导出SimC APL': 'Export SimC APL',
+  '已切换为简化视图模式，仅显示主技能。':
+    'Switched to compact view mode, only main skills are shown.',
 };
 
 export function t(zh: string): string {


### PR DESCRIPTION
## Summary
- filter timeline when zoomed out to show only main cooldowns
- switch events to box display in compact mode
- display notice on automatic mode change
- add English translation for the notice

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889056b8c94832f86aa61a02a66b1d5