### PR TITLE
Fix timeline time formatting and hover tooltips

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,7 +103,7 @@ function recomputeTimeline(
         ...items[idx],
         end: duration > 0 ? it.start + duration : undefined,
         type: duration > 0 ? 'guide' : undefined,
-        ...(ability.cast ? { title: duration > 0 ? `Cast Duration: ${duration.toFixed(2)}s` : undefined } : {}),
+        ...(ability.cast ? { title: duration > 0 ? `Cast Duration: ${duration.toFixed(1)}s` : undefined } : {}),
         className: baseCls.join(' '),
       };
     }
@@ -193,7 +193,7 @@ function recomputeTimeline(
       if (idx >= 0) {
         items[idx] = {
           ...items[idx],
-          title: `FoF -${fofReduced.toFixed(2)}s, RSK -${rskReduced.toFixed(2)}s`,
+          title: `FoF -${fofReduced.toFixed(1)}s, RSK -${rskReduced.toFixed(1)}s`,
         };
       }
     }
@@ -206,7 +206,7 @@ function recomputeTimeline(
     }
   }
   const total = Math.max(0, ...items.map(i => (i.end ?? i.start)));
-  console.log('Recomputed full timeline from 0 to ' + total.toFixed(2) + 's');
+  console.log('Recomputed full timeline from 0 to ' + total.toFixed(1) + 's');
   return { items, buffs, casts, chi };
 }
 
@@ -251,9 +251,7 @@ export default function App() {
   }, [dispatch]);
 
   const formatTime = (sec: number) => {
-    const m = Math.floor(sec / 60).toString().padStart(2, '0');
-    const s = Math.floor(sec % 60).toString().padStart(2, '0');
-    return `${m}:${s}`;
+    return `${sec.toFixed(1)}s`;
   };
 
 
@@ -447,7 +445,7 @@ export default function App() {
         label,
         ability: key,
         className: key,
-        ...(castDur > 0 ? { title: `Cast Duration: ${castDur.toFixed(2)}s` } : {}),
+        ...(castDur > 0 ? { title: `Cast Duration: ${castDur.toFixed(1)}s` } : {}),
         pendingDelete: false,
         type: itemType,
       },
@@ -512,7 +510,7 @@ export default function App() {
       `[${startTime.toFixed(3)}s] Cast ${key} → spent ${actualCost} Chi (original ${originalCost})` +
       (chiGain > 0 ? `, gained ${chiGain} Chi` : '') +
       (key === 'RSK' || key === 'RSK_HL' ? ', Acclamation triggered' : '') +
-      (extension > 0 ? `, SEF extended by ${extension.toFixed(2)}s` : '') +
+      (extension > 0 ? `, SEF extended by ${extension.toFixed(1)}s` : '') +
       `, Chi now: ${Math.max(0, Math.min(6, chi - actualCost + chiGain))}`
     );
 
@@ -560,8 +558,8 @@ export default function App() {
             it.id === id
               ? {
                   ...it,
-                  title: `FoF -${fofReduced.toFixed(2)}s, RSK -${rskReduced.toFixed(
-                    2,
+                  title: `FoF -${fofReduced.toFixed(1)}s, RSK -${rskReduced.toFixed(
+                    1,
                   )}s`,
                 }
               : it,
@@ -668,7 +666,7 @@ export default function App() {
           group: 9,
           start: s,
           end: e,
-          label: `+${extra.toFixed(2)}s/s`,
+          label: `+${extra.toFixed(1)}s/s`,
           className: 'buff',
         });
       }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -141,13 +141,8 @@ export const Timeline = ({
           callback(item);
         },
         format: {
-          minorLabels: (date: any) => {
-            const sec = Math.floor(date.valueOf() / 1000);
-            const m = String(Math.floor(sec / 60)).padStart(2, "0");
-            const s = String(sec % 60).padStart(2, "0");
-            return `${m}:${s}`;
-          },
-          majorLabels: () => "",
+          minorLabels: (date: any) => (date.valueOf() / 1000).toFixed(1) + 's',
+          majorLabels: () => '',
         },
       },
     );
@@ -223,6 +218,7 @@ export const Timeline = ({
     const tl = timelineRef.current;
     if (!cursorAdded.current) {
       tl.addCustomTime(new Date(cursor * 1000), "cursor");
+      tl.setCustomTimeTitle('', 'cursor');
       cursorAdded.current = true;
     } else {
       tl.setCustomTime(new Date(cursor * 1000), "cursor");
@@ -240,6 +236,7 @@ export const Timeline = ({
         const id = `cd-${c.id}-${Math.random()}`;
         cdIds.current.push(id);
         tl.addCustomTime(new Date(c.time * 1000), id);
+        tl.setCustomTimeTitle('', id);
       });
     }
   }, [cds, showCD]);

--- a/src/util/fmt.ts
+++ b/src/util/fmt.ts
@@ -1,1 +1,1 @@
-export const fmt = (v: number) => v.toFixed(2);
+export const fmt = (v: number) => v.toFixed(1);


### PR DESCRIPTION
## Summary
- ensure all timeline time displays use one decimal
- prevent default date tooltip on custom lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a72f3661c832fad80a985bac96592