### PR TITLE
Update SW buff duration and Blessing haste

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <title>Shellwalker</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/jpeg" href="assets/abilityIcons/ability_monk_hurricanestrike.jpg" />
 </head>
 <body>
   <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ function computeBlessingBuffs(dragons: CalcBuff[]): CalcBuff[] {
       end,
       label: t('祝福'),
       group: 8,
-      multiplier: 1.15,
+      multiplier: 1.1,
       source,
     });
   };
@@ -140,7 +140,7 @@ function recomputeTimeline(
     if (key === 'AA') {
       buffs.push({ id: --nid, key: 'AA_BD', start: it.start, end: it.start + 6, label: t('AA青龙'), group: 9, src: it.id });
     } else if (key === 'SW') {
-      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 8, label: t('SW青龙'), group: 9, src: it.id });
+      buffs.push({ id: --nid, key: 'SW_BD', start: it.start + dur, end: it.start + dur + 4, label: t('SW青龙'), group: 9, src: it.id });
     } else if (key === 'CC') {
       const start = it.start + dur;
       buffs = buffs.map(b => (b.key === 'AA_BD' && b.start <= start && start < b.end ? { ...b, end: start } : b));
@@ -455,7 +455,7 @@ export default function App() {
       extraBuffs.push({ id: nextBuffId, key: 'AA_BD', start: startTime, end: startTime + 6, label: t('AA青龙'), src: id, group: 9 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'SW') {
-      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: startTime + castDur, end: startTime + castDur + 8, label: t('SW青龙'), src: id, group: 9 } as any);
+      extraBuffs.push({ id: nextBuffId, key: 'SW_BD', start: startTime + castDur, end: startTime + castDur + 4, label: t('SW青龙'), src: id, group: 9 } as any);
       setNextBuffId(nextBuffId - 1);
     } else if (key === 'CC') {
       const start = startTime + castDur;
@@ -636,7 +636,7 @@ export default function App() {
         end,
         label: t('祝福'),
         group: 7,
-        multiplier: 1.15,
+        multiplier: 1.1,
         source,
       } as Buff);
     };

--- a/src/constants/buffs.ts
+++ b/src/constants/buffs.ts
@@ -3,7 +3,7 @@ export type DragonType = typeof DRAGON_TYPES[number];
 
 export const BUFF_DURATION: Record<DragonType | 'Blessing', number> = {
   AA: 6,
-  SW: 8,
+  SW: 4,
   CC: 6,
   Blessing: 4,
 };
@@ -21,4 +21,4 @@ export const FOF_SPEED = {
   SW_WITH_OTHERS: 0.25,
 };
 
-export const BLESSING_HASTE = 1.15;
+export const BLESSING_HASTE = 1.1;

--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -110,7 +110,7 @@ export function cast(state: RootState, abilityId: string) {
   if (abilityId === 'AA') {
     state.buffs.push({ key: 'AA', start: state.now, end: state.now + 6000 });
   } else if (abilityId === 'SW') {
-    state.buffs.push({ key: 'SW', start: state.now, end: state.now + 8000 });
+    state.buffs.push({ key: 'SW', start: state.now, end: state.now + 4000 });
   } else if (abilityId === 'CC') {
     state.buffs.push({ key: 'CC', start: state.now, end: state.now + 6000 });
   } else if (abilityId === 'BL') {

--- a/tests/azureDragonHeart.test.ts
+++ b/tests/azureDragonHeart.test.ts
@@ -30,7 +30,7 @@ describe('azure dragon', () => {
     assert.equal(mgr.activeDragons(6).length, 1);
     const b = mgr.blessing(6);
     assert.ok(b);
-    assert.equal(hasteMult(mgr,6), 1.15);
+    assert.equal(hasteMult(mgr,6), 1.1);
     mgr.advance(12);
     assert.ok(b.end >= 10);
   });

--- a/tests/blessing.spec.ts
+++ b/tests/blessing.spec.ts
@@ -24,9 +24,9 @@ describe('Blessing stacks', () => {
     mgr.advance(10);
     const stacksAt10 = mgr.activeBlessings(10);
     expect(stacksAt10.length).toBe(2);
-    const sw = stacksAt10.find(b => b.source === 'SW');
-    expect(sw && Math.abs(sw.end - 17.4) < 0.001).toBe(true);
-    expect(hasteMult(mgr, 10)).toBeCloseTo(Math.pow(1.15, 2), 2);
+    const sources = stacksAt10.map(b => b.source);
+    expect(sources.every(s => s === 'POST')).toBe(true);
+    expect(hasteMult(mgr, 10)).toBeCloseTo(Math.pow(1.1, 2), 2);
   });
 
   it('segments show stack labels', () => {

--- a/tests/blessing_haste.spec.ts
+++ b/tests/blessing_haste.spec.ts
@@ -4,15 +4,15 @@ import { getEndAt } from '../src/utils/getEndAt';
 import type { Buff } from '../src/lib/cooldown';
 
 function b(start: number, end: number): Buff {
-  return { start, end, multiplier: 1.15 } as any;
+  return { start, end, multiplier: 1.1 } as any;
 }
 
 describe('blessing haste precision', () => {
   it('calculates correct blessing haste', () => {
     const buffs: Buff[] = [b(0, 5000), b(0, 5000)];
-    expect(selectBlessingHaste(buffs as any, 1000)).toBeCloseTo(Math.pow(1.15, 2), 5);
+    expect(selectBlessingHaste(buffs as any, 1000)).toBeCloseTo(Math.pow(1.1, 2), 5);
     buffs.push(b(1500, 5500));
-    expect(selectBlessingHaste(buffs as any, 2000)).toBeCloseTo(Math.pow(1.15, 3), 5);
+    expect(selectBlessingHaste(buffs as any, 2000)).toBeCloseTo(Math.pow(1.1, 3), 5);
   });
 
   it('FoF cd uses un-rounded total haste', () => {

--- a/tests/bok_cooldown.spec.ts
+++ b/tests/bok_cooldown.spec.ts
@@ -18,15 +18,15 @@ describe('Blackout Kick cooldown reduction', () => {
   });
 
   it('reduces FoF by 1.75s with SW buff', () => {
-    const sw: Buff = { key: 'SW_BD', start: 0, end: 8 } as any;
+    const sw: Buff = { key: 'SW_BD', start: 0, end: 4 } as any;
     const buffs: Buff[] = [sw];
     const fof: SkillCast = { id: 'FoF', start: 0, base: 24 };
     const end = cdEnd(fof.start, fof.base, buffs, cdSpeedAt);
-    expect(end).toBeCloseTo(18, 3); // 8s at 1.75 speed then 10s at 1x
+    expect(end).toBeCloseTo(21, 3); // 4s at 1.75 speed then 17s at 1x
     const reduction = cdSpeedAt(1, buffs); // 1.75
     const newEnd = Math.max(1, end - reduction);
     const newBase = cdProgress(fof.start, newEnd, buffs, cdSpeedAt);
     const updated: SkillCast = { ...fof, base: newBase };
-    expect(cdEnd(updated.start, updated.base, buffs, cdSpeedAt)).toBeCloseTo(16.25, 3);
+    expect(cdEnd(updated.start, updated.base, buffs, cdSpeedAt)).toBeCloseTo(19.25, 3);
   });
 });

--- a/tests/dragon_sync.spec.ts
+++ b/tests/dragon_sync.spec.ts
@@ -12,7 +12,7 @@ it('AA+SW overlap sweeps 3.0625s per s', () => {
   cast(state, 'SW');
   cast(state, 'YH');
   advanceTime(state, 5000);
-  expect(getCooldown(state, 'YH')).toBeCloseTo(30000 - 5000 * 3.0625, 0);
+  expect(getCooldown(state, 'YH')).toBeCloseTo(16750, 0);
 });
 
 it('haste added mid-cd accelerates', () => {

--- a/tests/dynamic_cast.spec.ts
+++ b/tests/dynamic_cast.spec.ts
@@ -11,7 +11,7 @@ describe('calcDynamicEndTime', () => {
   });
 
   it('dragon speed applies', () => {
-    const sw = { key: 'SW_BD', start: 0, end: 8 };
+    const sw = { key: 'SW_BD', start: 0, end: 4 };
     const end = calcDynamicEndTime(0, 4, [sw], [], 0, ['AA_BD','SW_BD','CC_BD']);
     expect(end).toBeCloseTo(2, 3);
   });


### PR DESCRIPTION
## Summary
- shorten Slicing Winds buff to 4s
- reduce Blessing haste to 10% per stack
- update timeline logic to use new SW duration
- tweak tests for new values
- add favicon referencing Hurricane Strike

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ac75c9d0c832f9873e6e50e63767b