### PR TITLE
Fix blessing stack deduplication

### DIFF
--- a/tests/blessing.spec.ts
+++ b/tests/blessing.spec.ts
@@ -23,10 +23,9 @@ describe('Blessing stacks', () => {
     // advance to CC expiration (10s)
     mgr.advance(10);
     const stacksAt10 = mgr.activeBlessings(10);
-    expect(stacksAt10.length).toBe(2);
-    const sources = stacksAt10.map(b => b.source);
-    expect(sources.every(s => s === 'POST')).toBe(true);
-    expect(hasteMult(mgr, 10)).toBeCloseTo(Math.pow(1.1, 2), 2);
+    expect(stacksAt10.length).toBe(1);
+    expect(stacksAt10[0].source).toBe('POST');
+    expect(hasteMult(mgr, 10)).toBeCloseTo(1.1, 2);
   });
 
   it('segments show stack labels', () => {


### PR DESCRIPTION
## Summary
- avoid duplicate blessing sources and tie CC-AA synergy to a single source
- only add tail blessing when last dragon buff ends
- surface blessing stack sources in timeline tooltips
- update blessing stack unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aec322168832f903e63334db42161