### PR TITLE
Fix haste scaling for Celestial Conduit

### DIFF
--- a/src/lib/haste.ts
+++ b/src/lib/haste.ts
@@ -74,6 +74,5 @@ export function selectTotalHasteAt(
   rating: number,
   t: number,
 ) {
-  const gear = 1 + ratingToHaste(rating);
-  return gear * selectBloodlustHaste(buffs, t) * selectBlessingHaste(buffs, t);
+  return hasteAt(t, buffs, rating);
 }

--- a/tests/channel_dynamic.spec.ts
+++ b/tests/channel_dynamic.spec.ts
@@ -48,3 +48,12 @@ it('CC channel reacts to Bloodlust added after cast', () => {
   cast(s, 'BL');
   expect(selectRemCC(s)).toBeLessThan(before);
 });
+
+
+it('CC channel scales with extra haste buff', () => {
+  setGearHastePercent(s, 0);
+  s.buffs.push({ key: 'Xuen', start: 0, end: 5000, multiplier: 1.33 } as any);
+  cast(s, 'CC');
+  const rem = selectRemCC(s);
+  expect(rem).toBeCloseTo(1150, 0);
+});


### PR DESCRIPTION
## Summary
- compute total haste using all buff multipliers
- test Celestial Conduit with a generic haste buff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b1af26a6c832fad6b112094c8c722