### PR TITLE
Fix CC channel haste handling

### DIFF
--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,5 +1,5 @@
 import { abilityById } from '../constants/abilities';
-import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
+import { hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
 import { sweepRate } from '../utils/dragonSweep';
 
@@ -80,7 +80,7 @@ export function dragonsOverlap(state: RootState, t: number) {
 
 export function selectTotalHasteAt(state: RootState, t: number) {
   const rating = gearRatingAt(state, t);
-  return hasteAt(state.buffs, rating, t);
+  return hasteAt(t, state.buffs, rating);
 }
 
 export function getEffectiveTickRate(
@@ -113,6 +113,12 @@ export function cast(state: RootState, abilityId: string) {
     state.buffs.push({ key: 'SW', start: state.now, end: state.now + 4000 });
   } else if (abilityId === 'CC') {
     state.buffs.push({ key: 'CC', start: state.now, end: state.now + 6000 });
+    const h = selectTotalHasteAt(state, state.now);
+    console.log(
+      `[DEBUG][CC] at t=${state.now}ms, totalHaste=${h.toFixed(2)}, expectedDuration=${(
+        (ability.baseChannelMs ?? 0) / h
+      ).toFixed(2)}ms`,
+    );
   } else if (abilityId === 'BL') {
     state.buffs.push({ key: 'BL', start: state.now, end: state.now + 40000, multiplier: 1.3 });
   }

--- a/tests/channel_live.spec.ts
+++ b/tests/channel_live.spec.ts
@@ -42,6 +42,14 @@ it('CC channel reacts to gear haste change', () => {
   expect(selectRemCC(s)).toBeLessThan(before);
 });
 
+it('CC channel = 1.5s/total haste', () => {
+  setGearHastePercent(s, 0.20); // gear 1.2×
+  cast(s, 'BL'); // +30%
+  cast(s, 'CC');
+  const rem = selectRemCC(s);
+  expect(rem).toBeCloseTo(1500 / (1.2 * 1.3), 0);
+});
+
 it('SCK channel = 1.5s/haste', () => {
   setGearHastePercent(s, 0.20); // 1.2×
   cast(s, 'SCK');


### PR DESCRIPTION
## Summary
- compute total haste with `hasteAt` for dynamic engine
- log CC channel haste snapshot for debugging
- test CC channel duration against total haste

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b1d80ab14832f8a33ef4f9f4c3956