### PR TITLE
Fix CC channel haste calc

### DIFF
--- a/src/logic/dynamicEngine.ts
+++ b/src/logic/dynamicEngine.ts
@@ -1,5 +1,5 @@
 import { abilityById } from '../constants/abilities';
-import { selectTotalHasteAt as hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
+import { hasteAt, ratingToHaste, HasteBuff } from '../lib/haste';
 import { elapsedCdMs } from '../utils/cooldownIntegrate';
 import { sweepRate } from '../utils/dragonSweep';
 
@@ -80,7 +80,7 @@ export function dragonsOverlap(state: RootState, t: number) {
 
 export function selectTotalHasteAt(state: RootState, t: number) {
   const rating = gearRatingAt(state, t);
-  return hasteAt(state.buffs, rating, t);
+  return hasteAt(t, state.buffs, rating);
 }
 
 export function getEffectiveTickRate(

--- a/src/selectors/channel.ts
+++ b/src/selectors/channel.ts
@@ -15,6 +15,14 @@ export function selectRemainingChannel(state: RootState, id: string) {
   if (cast == null) return 0;
   const ability = abilityById(id);
   const base = ability.baseChannelMs ?? 0;
+  if (id === 'CC' && ability.channelDynamic) {
+    const h = selectTotalHasteAt(state, cast);
+    console.log(
+      `[DEBUG][CC] at t=${cast}ms, totalHaste=${h.toFixed(2)}, expectedDuration=${(
+        base / h
+      ).toFixed(2)}ms`,
+    );
+  }
   const dt = 50;
   let t = cast;
   let done = 0;


### PR DESCRIPTION
## Summary
- use generic `hasteAt` when computing haste in dynamic engine
- log CC channel debugging info about haste and expected duration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b1d80ab14832f8a33ef4f9f4c3956